### PR TITLE
Committing recent evolutions in the sync code and adding TFC plugin

### DIFF
--- a/docker/CMSRucioClient/scripts/cmstfc_lfn2pfn.py
+++ b/docker/CMSRucioClient/scripts/cmstfc_lfn2pfn.py
@@ -1,0 +1,82 @@
+"""
+LFN-to-path algorithms for TFC
+"""
+import re
+
+from rucio.rse.protocols.protocol import RSEDeterministicTranslation
+
+def cmstfc(scope, name, rse, rse_attrs, proto_attrs):
+    """
+    Map lfn into pfn accoring to the declared tfc in the protocol.
+
+    """
+
+    # Prevents unused argument warnings in pylint
+    del rse
+    del rse_attrs
+    del scope
+
+    # Getting the TFC
+    tfc = proto_attrs['extended_attributes']['tfc']
+    tfc_proto = proto_attrs['extended_attributes']['tfc_proto']
+
+    # matching the lfn into a pfn
+    pfn = tfc_lfn2pfn(name, tfc, tfc_proto)
+
+    # now we have to remove the protocol part of the pfn
+    proto_pfn = proto_attrs['scheme'] + '://' + \
+       proto_attrs['hostname'] + ':' + str(proto_attrs['port'])
+    if 'extended_attributes' in proto_attrs and \
+        'web_service_path' in proto_attrs['extended_attributes']:
+        proto_pfn += proto_attrs['extended_attributes']['web_service_path']
+    proto_pfn += proto_attrs['prefix']
+
+    return pfn.replace(proto_pfn, "")
+
+def tfc_lfn2pfn(lfn, tfc, proto):
+    """
+    Performs the actual tfc matching
+    """
+
+    for rule in tfc:
+        if (rule['element_name'] == 'lfn-to-pfn') and (rule['protocol'] == proto):
+            regex = re.compile(rule['path-match'])
+            if regex.match(lfn):
+                if 'chain' in rule:
+                    lfn = tfc_lfn2pfn(lfn, tfc, rule['chain'])
+                    return regex.sub(rule['result'].replace('$', '\\'), lfn)
+
+    raise ValueError("lfn %s with proto %s cannot be matched" % (lfn, proto))
+
+RSEDeterministicTranslation.register(cmstfc)
+
+
+if __name__ == '__main__':
+
+    PROTO_ATTRS = {
+        'extended_attributes': {'tfc_proto': 'srmv2', 'web_service_path': '/srm/managerv2?SFN=',\
+        'tfc': [
+            {'destination-match': '.*', 'protocol': 'direct',
+             'result': '/dpm/in2p3.fr/home/cms/trivcat/$1',
+             'element_name': 'lfn-to-pfn', 'path-match': u'/+(.*)'},
+            {'protocol': 'srmv2', 'chain': 'direct', 'destination-match': '.*',
+             'result': 'srm://polgrid4.in2p3.fr:8446/srm/managerv2?SFN=/$1',
+             'path-match': '/+(.*)', 'element_name': 'lfn-to-pfn'}
+        ]},
+        'hostname': 'polgrid4.in2p3.fr', 'prefix': '/dpm', 'scheme': 'srm', 'port': 8446
+    }
+
+
+    def test_tfc_mapping(name, pfn, scope="cms"):
+        """
+        Unit test for lfn to pfn mapping
+        """
+
+        mapped_pfn = cmstfc(scope, name, None, None, PROTO_ATTRS)
+        if mapped_pfn == pfn:
+            print "%s:%s -> %s" % (scope, name, pfn)
+        else:
+            print "FAILURE: %s:%s -> %s (expected %s)" % (scope, name, mapped_pfn, pfn)
+
+    test_tfc_mapping("/store/some/path/file.root",
+                     "/in2p3.fr/home/cms/trivcat/store/some/path/file.root")

--- a/docker/CMSRucioClient/scripts/cmstfc_lfn2pfn.py
+++ b/docker/CMSRucioClient/scripts/cmstfc_lfn2pfn.py
@@ -44,9 +44,9 @@ def tfc_lfn2pfn(lfn, tfc, proto):
             if regex.match(lfn):
                 if 'chain' in rule:
                     lfn = tfc_lfn2pfn(lfn, tfc, rule['chain'])
-                    return regex.sub(rule['result'].replace('$', '\\'), lfn)
+                return regex.sub(rule['result'].replace('$', '\\'), lfn)
 
-    raise ValueError("lfn %s with proto %s cannot be matched" % (lfn, proto))
+    raise ValueError("lfn %s with proto %s cannot be matched by tfc %s" % (lfn, proto, tfc))
 
 RSEDeterministicTranslation.register(cmstfc)
 


### PR DESCRIPTION
Disregarding good practices, this commits contains several (unrelated) things
- adding the `cmstfc_lfn2pfn.py` plugin (if merged, in the doc for the evaluation committee we can point to the dmwm githhub repo rather than mine)
- some improvements in the `CMSRucio.py` module
   - using rucio.client.client.Client rather than different clients for DID, Replicas, ...
   - added `get_file_url`, `get_global_url` and `check_storage` method which where previously in `syncSite.py`
   - added some checks and retries for das and data service
   - some bug fixes and pylint suggested changes
- some improvements in the `syncSite.py` tool
   - added class NodeSync for injecting into the RSE protocol extended attributes the relevant TFC rules
   - added `get_transferred_datasets` that gets the list of datasets subscribed in the last N days (added the corresponding `-subdays` command line option)
   - added command line option '-filter' for filtering on datasets names
   - implemented a debug mode which runs in single thread on an alphanumerically list of datasets (which makes the debug way easier) and added the corresponding `-debug` command line option
   - fixed some bugs and made some pylint suggested changes

