### PR TITLE
workaround for a bug in list_replicas

### DIFF
--- a/docker/CMSRucioClient/scripts/cmsdatareplica.py
+++ b/docker/CMSRucioClient/scripts/cmsdatareplica.py
@@ -198,7 +198,10 @@ class CMSRucioDatasetReplica(object):
         replicas = self.rcli.list_replicas([{'scope': self.scope, 'name': self.dataset}],
                                            rse_expression='rse=%s' % self.rse)
 
-        rrepl = [repl['name'] for repl in replicas]
+        try:
+            rrepl = [repl['name'] for repl in replicas]
+        except TypeError:
+            rrepl = []
 
         prepl = [repl for repl in self.replicas.keys()]
 

--- a/docker/CMSRucioClient/scripts/synccmssites.py
+++ b/docker/CMSRucioClient/scripts/synccmssites.py
@@ -66,6 +66,7 @@ DEFAULT_PNN_CONF = {
     'multi_das_calls': False,
     'select': [r'\S+'],
     'ignore': [],
+    'min_deletions': 50,
 }
 
 DEFAULT_MAIN_CONF = {
@@ -345,7 +346,7 @@ def pnn_sync(pnn, pcli):
     logging.notice("Launched %d workers, pool size %d, timing %s", summary['workers'],
                    int(conf['pool']), summary['timing']['_launch_pnn_workers'])
 
-    left = int(conf['chunck']) - summary['workers']
+    left = int(conf['chunck']) - summary['workers'] + int(conf['min_deletions'])
 
     if left > 0:
         workers_st = get_timing(


### PR DESCRIPTION
Workaround for the list_replicas bug (just catching the exception and returning an empty list). Also pushing a change in synccmssites done some time ago to force the script running some deletions even when sites are heavily out of sync.