### PR TITLE
Sync T1 tape sites as RSE '_Tape'

### DIFF
--- a/docker/CMSRucioClient/scripts/cmsrses.py
+++ b/docker/CMSRucioClient/scripts/cmsrses.py
@@ -79,7 +79,14 @@ class CMSRSE(object):
             suffix = DEFAULT_SUFFIXES[rsetype]
 
         self.suffix = suffix
-        self.rsename = pnn + self.suffix
+        if pnn.endswith('_MSS'):
+            raise ValueError('Please import PhEDEx _Buffer pnns rather than _MSS for tape endpoints')
+        elif pnn.endswith('_Buffer'):
+             self.rsename = pnn.replace('_Buffer', '_Tape') + self.suffix
+             self.rucio_rse_type = 'TAPE'
+        else:
+             self.rsename = pnn + self.suffix
+             self.rucio_rse_type = 'DISK'
 
         if tfc and os.path.isdir(tfc):
             self.tfc = tfc + '/' + pnn + '/PhEDEx/storage.xml'
@@ -327,10 +334,10 @@ class CMSRSE(object):
 
         if create:
             if self.dry:
-                logging.info('creating rse %s with deterministic %s. Dry run, skipping',
-                             self.rsename, self.settings['deterministic'])
+                logging.info('creating rse %s with deterministic %s and type %s. Dry run, skipping',
+                             self.rsename, self.settings['deterministic'], self.rucio_rse_type)
             else:
-                self.rcli.add_rse(self.rsename, deterministic=self.settings['deterministic'])
+                self.rcli.add_rse(self.rsename, deterministic=self.settings['deterministic'], rse_type=self.rucio_rse_type)
                 logging.debug('created rse %s', self.rsename)
 
         return create

--- a/docker/CMSRucioClient/scripts/k8s_sync_sites.sh
+++ b/docker/CMSRucioClient/scripts/k8s_sync_sites.sh
@@ -20,8 +20,8 @@ echo Using config file in $RUCIO_HOME
 
 cd docker/CMSRucioClient/scripts/
 
-#  Removed --exclude 'T2_US_Florida'
 ./cmsrses.py --pnn all --select 'T2_\S+' --exclude '\S+RAL\S*' --exclude '\S+Nebraska\S*' --exclude 'T2_MY_\S+' --exclude '\S+CERN\S+' --type real --type temp --type test --fts https://fts3.cern.ch:8446
+./cmsrses.py --pnn all --select 'T1_\S+' --exclude '.*MSS' --type real --type test --fts https://fts3.cern.ch:8446 --dry
 ./syncaccounts.py --identity "/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=cmsrucio/CN=430796/CN=Robot: CMS Rucio Data Transfer" --type x509
 ./cmslinks.py --phedex_link --overwrite --disable
 


### PR DESCRIPTION
Set to `--dry` run in cronjob script.  Let's put it in, see if the dry run looks ok, then fix.
Can remove `_Buffer` manually.  Need to check also if this will work with the dataset sync script, when we start to sync Tape over. @sartiran do you know off-hand if the RSE `pnn` attribute is used to link the RSE to the PhEDEx node for sync?