### PR TITLE
Correct prefix for few broken RSE

### DIFF
--- a/docker/CMSRucioClient/scripts/cmsrses.py
+++ b/docker/CMSRucioClient/scripts/cmsrses.py
@@ -272,7 +272,13 @@ class CMSRSE(object):
             self.proto['extended_attributes']['tfc'] = self.tfc
             self._check_lfn2pfn()
         else:
-            self.proto['prefix'] = seinfo['prefix']
+            if self.rsetype == "temp":
+                if 'webpath' in seinfo:
+                    self.proto['prefix'] = seinfo['prefix']
+                else:
+                    self.proto['prefix'] = '/' + seinfo['prefix']
+            else:
+                self.proto['prefix'] = seinfo['prefix']
 
         if add_prefix is None:
             add_prefix = SE_ADD_PREFIX_BYTYPE[self.rsetype]


### PR DESCRIPTION
Adding one `/` to fix https://its.cern.ch/jira/browse/CMSRUCIO-221

Tested on a T2_US_Florida_Temp and T2_US_Purdue on int server, and they look on now.

Still not optimal, we might need to understand why this is happening at Rucio level