### PR TITLE
Adding webDAV and fixing dryrun and  _get_protocol regexp logic

### DIFF
--- a/docker/CMSRucioClient/scripts/CMSRSE.py
+++ b/docker/CMSRucioClient/scripts/CMSRSE.py
@@ -298,7 +298,6 @@ class CMSRSE:
                         protocol_unchanged = True
                     else:
                         if self.dry:
-                                         y
                             logging.info("Deleting definition which is not as expected: \nrucio=%s  \nexpected=%s. Dry run, skipping",
                                          str(existing_proto), str(new_proto))
                         else:

--- a/docker/CMSRucioClient/scripts/CMSRSE.py
+++ b/docker/CMSRucioClient/scripts/CMSRSE.py
@@ -309,11 +309,11 @@ class CMSRSE:
                                 logging.debug("Cannot remove protocol %s from %s", new_proto['scheme'], self.rse_name)
 
             if new_proto['scheme'] in ['srm', 'srmv2', 'gsiftp', 'davs'] and not protocol_unchanged:
-            if self.dry:
-                logging.info('Adding %s to %s. Dry run, skipping', new_proto['scheme'], self.rse_name)
-            else:
-                logging.info('Adding %s to %s', new_proto['scheme'], self.rse_name)
-                self.rcli.add_protocol(rse=self.rse_name, params=new_proto)
+                if self.dry:
+                    logging.info('Adding %s to %s. Dry run, skipping', new_proto['scheme'], self.rse_name)
+                else:
+                    logging.info('Adding %s to %s', new_proto['scheme'], self.rse_name)
+                    self.rcli.add_protocol(rse=self.rse_name, params=new_proto)
 
         return
 


### PR DESCRIPTION
This PR:

1. adds support for webDAV, although it is currently disabled
2. fixes the dryrun in _set_protocols
3. fixes the regexp logic in _get_protocol that doesn't allow a rule like this:
https://gitlab.cern.ch/SITECONF/T2_US_UCSD/-/blob/master/storage.json#L37
