### PR TITLE
Split cron jobs into two Fix #217

### DIFF
--- a/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
+++ b/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
@@ -22,21 +22,17 @@ set -x
 
 cd docker/CMSRucioClient/scripts/
 
-echo "Syncing sites from JSON"
+echo "Syncing account roles for managers and group accounts"
+./syncRolesToAttributes.py
+./syncEgroupsToGroupAccounts.py
 
-if [ "$RUCIO_HOME" = "/opt/rucio-int" ]
-  then
-  ./setRucioFromGitlab --type int-real
-fi
 if [ "$RUCIO_HOME" = "/opt/rucio-prod" ]
   then
-  ./setRucioFromGitlab --type prod-real
+  echo "Creating user accounts and setting quotas"
+  ./user_to_site_mapping.py
 fi
 
-./setRucioFromGitlab --type test
-./setRucioFromGitlab --type temp
 
-echo "Setting quotas"
-./setSiteQuotas
-echo "Setting availability"
-./setSiteAvailability
+echo "Creating links"
+./cmslinks.py --overwrite # Remove the --disable flag for Katy's RSE
+## ./cmslinks.py --phedex_link --overwrite --disable

--- a/docker/CMSRucioClient/scripts/syncEgroupsToGroupAccounts.py
+++ b/docker/CMSRucioClient/scripts/syncEgroupsToGroupAccounts.py
@@ -23,6 +23,7 @@ def sync_egroups_to_group_accounts():
             group_email = data['egroups'][0] + '@cern.ch'
 
             try:
+                print('Checking for account %s in Rucio' % group_name)
                 client.get_account(group_name)
             except AccountNotFound:
                 print('Adding group account %s with %s' % (group_name, group_email))


### PR DESCRIPTION
Split the cronjobs into two pieces putting the most urgent in one hour. Also requires a CMSKubernetes change to helm