### PR TITLE
Update cmslinks.py

### DIFF
--- a/docker/CMSRucioClient/scripts/cmslinks.py
+++ b/docker/CMSRucioClient/scripts/cmslinks.py
@@ -15,6 +15,7 @@ from rucio.client import Client
 DEFAULT_EXCLUDE_LINKS = (
     {'dest': {'type': 'temp'}, 'src': {}},
     {'dest': {'rse': 'T2_US_Caltech'}, 'src': {'rse': 'T2_US_Caltech_Ceph'}},
+    {'dest': {'rse': 'T1_UK_RAL_Tape_Test'}, 'src': {'rse': 'T1_UK_RAL_Tape_Test'}},
 )
 
 CTA_RSES = ['T0_CH_CERN_Tape']

--- a/docker/CMSRucioClient/scripts/cmslinks.py
+++ b/docker/CMSRucioClient/scripts/cmslinks.py
@@ -15,7 +15,8 @@ from rucio.client import Client
 DEFAULT_EXCLUDE_LINKS = (
     {'dest': {'type': 'temp'}, 'src': {}},
     {'dest': {'rse': 'T2_US_Caltech'}, 'src': {'rse': 'T2_US_Caltech_Ceph'}},
-    {'dest': {'rse': 'T1_UK_RAL_Tape_Test'}, 'src': {'rse': 'T1_UK_RAL_Tape_Test'}},
+    {'dest': {'rse': 'T1_UK_RAL_Tape_Test'}, 'src': {}},
+    {'dest': {}, 'src': {'rse': 'T1_UK_RAL_Tape_Test'}},
 )
 
 CTA_RSES = ['T0_CH_CERN_Tape']


### PR DESCRIPTION
Excluding RAL_Tape_Test from the automatic link creation. This is because this is being tested as a new 'CTA-type' RSE, which will only be connected directly to certain sites via multihop.