### PR TITLE
Update cmslinks.py

### DIFF
--- a/docker/CMSRucioClient/scripts/cmslinks.py
+++ b/docker/CMSRucioClient/scripts/cmslinks.py
@@ -17,6 +17,8 @@ DEFAULT_EXCLUDE_LINKS = (
     {'dest': {'rse': 'T2_US_Caltech'}, 'src': {'rse': 'T2_US_Caltech_Ceph'}},
     {'dest': {'rse': 'T1_UK_RAL_Tape_Test'}, 'src': {}},
     {'dest': {}, 'src': {'rse': 'T1_UK_RAL_Tape_Test'}},
+    {'dest': {'rse': 'T1_UK_RAL_Tape'}, 'src': {}},
+    {'dest': {}, 'src': {'rse': 'T1_UK_RAL_Tape'}},
 )
 
 CTA_RSES = ['T0_CH_CERN_Tape']


### PR DESCRIPTION
Adding T1_UK_RAL_Tape (not _Test) to the list of sites excluded from creation of 'all links'