### PR TITLE
Update setSiteAvailability - Skip LLR and IRFU

### DIFF
--- a/docker/CMSRucioClient/scripts/setSiteAvailability
+++ b/docker/CMSRucioClient/scripts/setSiteAvailability
@@ -12,7 +12,7 @@ import requests
 from rucio.client.client import Client
 from rucio.common.exception import RSENotFound
 
-SKIP_SITES = ['T3_US_NERSC', 'T2_US_Caltech_Ceph']
+SKIP_SITES = ['T3_US_NERSC', 'T2_US_Caltech_Ceph', 'T2_FR_GRIF_LLR', 'T2_FR_GRIF_IRFU']
 QUERY_HEADER = '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":["monit_prod_cmssst_*"]}'
 
 with open('availability_lucene.json', 'r') as lucene_json:


### PR DESCRIPTION
We are in the process of migrating `T2_FR_GRIF_LLR` and `T2_FR_GRIF_IRFU` to a single site `T2_FR_GRIF`. 
Meanwhile, we want to disable data writes to the site. https://its.cern.ch/jira/browse/CMSTRANSF-452.
Hence preventing auto-updates to availability status.