### PR TITLE
Adding ignore_availability flag to loadtest uploads

### DIFF
--- a/docker/CMSRucioClient/Dockerfile.loadtest
+++ b/docker/CMSRucioClient/Dockerfile.loadtest
@@ -1,6 +1,4 @@
-# No need for this file, just need to give the right entry point to the normal client
-
-FROM cmssw/rucio_client
+FROM registry.cern.ch/cmsrucio/rucio_client:latest
 
 COPY loadtest /loadtest
 


### PR DESCRIPTION
Load tests files should be reinstantiated even in the absence of write availability to avoid deadlocks with cmmsst.

Adding ReplicationRuleCreationTemporaryFailed exception during upload. Need to review the use of this again.