### PR TITLE
Adding custom role - site_capacity_manager - for T0 and T2 CERN Disks

### DIFF
--- a/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
+++ b/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
@@ -31,6 +31,8 @@ if [ "$RUCIO_HOME" = "/opt/rucio-prod" ]
   ./user_to_site_mapping.py
   echo "Adding group account scopes"
   ./account_to_scope_mapping.py --only-include-accounts-with-group-suffix 
+  echo "Syncing custom RSE Roles"
+  ./syncCustomRoles.py
 fi
 
 echo "Creating links"

--- a/docker/CMSRucioClient/scripts/syncCustomRoles.py
+++ b/docker/CMSRucioClient/scripts/syncCustomRoles.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python3
+import json
+import logging
+import os
+import requests
+
+from rucio.client import Client
+from argparse import ArgumentParser
+
+PROXY = os.getenv('X509_USER_PROXY')
+logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+def make_request(api_endpoint, cert=PROXY, verify=False):
+    # Pods don't like the CRIC certificate
+    result = requests.get(api_endpoint, cert=cert, verify=verify)
+    return json.loads(result.text)
+
+def add_site_capacity_manager_role(rucio_client, cric_endpoint, dry_run=False):
+    """
+    Add site capacity manager role to T2_CH_CERN and T0_CH_CERN_Disk RSEs
+    This syncs the cms-tier0-ops group to the site-capacity-manager attribute 
+    site-capacity-manager - The list of accounts that are allowed to manage the site capacity
+        For all other sites this attribute is not set and the capacity is automatically synced from cmssst SiteCapacity page 
+    """
+    logger = logging.getLogger("add_site_capacity_manager_role")
+
+    res = make_request(cric_endpoint)
+    users = res["CMS_TIER_0_OPS"]["users"]
+
+    accounts = set()
+    for user in users:
+        accounts.add(user["login"])
+
+    t0_rse_attr = rucio_client.list_rse_attributes("T0_CH_CERN_Disk")
+    current_t0_ch_cern_disk_capacity_managers = t0_rse_attr.get("site_capacity_manager", "")
+    current_t0_ch_cern_disk_capacity_managers = set(current_t0_ch_cern_disk_capacity_managers.split(","))
+
+    t2_rse_attr = rucio_client.list_rse_attributes("T2_CH_CERN")
+    current_t2_ch_cern_capacity_managers = t2_rse_attr.get("site_capacity_manager", "")
+    current_t2_ch_cern_capacity_managers = set(current_t2_ch_cern_capacity_managers.split(","))
+    
+    if current_t0_ch_cern_disk_capacity_managers == accounts and current_t2_ch_cern_capacity_managers == accounts:
+        logger.info("No changes to site capacity manager accounts")
+        return
+    
+    new_capacity_managers = ",".join(accounts)
+
+    if current_t0_ch_cern_disk_capacity_managers != accounts:
+        logger.info("Updating T0_CH_CERN_Disk site capacity manager accounts to %s", new_capacity_managers)
+        if not dry_run:
+            rucio_client.add_rse_attribute("T0_CH_CERN_Disk", "site_capacity_manager", new_capacity_managers)
+
+    if current_t2_ch_cern_capacity_managers != accounts:
+        logger.info("Updating T2_CH_CERN site capacity manager accounts to %s", new_capacity_managers)
+        if not dry_run:
+            rucio_client.add_rse_attribute("T2_CH_CERN", "site_capacity_manager", new_capacity_managers)
+
+
+
+if __name__=="__main__":
+    """
+    Sync Custome Roles:
+    Add site specific roles to RSE attributes from an external source such as CRIC
+    Each role addition shall be contained in a separate function
+    """
+    #Get Dry Run Option
+    parser = ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Dry run mode")
+    args = parser.parse_args()
+    dry_run = args.dry_run
+
+    rucio_client = Client()
+    add_site_capacity_manager_role(rucio_client, "https://cms-cric.cern.ch/api/accounts/group/query/?json&name=CMS_TIER_0_OPS", dry_run=dry_run)

--- a/src/policy/permission.py
+++ b/src/policy/permission.py
@@ -836,7 +836,19 @@ def perm_set_rse_usage(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer)
+    if _is_root(issuer):
+        return True
+
+    # Allow only site capacity managers to set usage
+    rse_id = kwargs.get('rse_id', None)
+    rse_attr = list_rse_attributes(rse_id=rse_id, session=session)
+    site_capacity_manager = rse_attr.get('site_capacity_manager', None)
+
+    if site_capacity_manager:
+        site_capacity_managers = site_capacity_manager.split(',')
+        if issuer.external in site_capacity_managers:
+            return True
+    return False
 
 
 def perm_set_rse_limits(issuer, kwargs, session=None):
@@ -848,7 +860,19 @@ def perm_set_rse_limits(issuer, kwargs, session=None):
     :param session: The DB session to use
     :returns: True if account is allowed to call the API call, otherwise False
     """
-    return _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session)
+    if _is_root(issuer) or has_account_attribute(account=issuer, key='admin', session=session):
+        return True
+
+    # Allow only site capacity managers to set usage
+    rse_id = kwargs.get('rse_id', None)
+    rse_attr = list_rse_attributes(rse_id=rse_id, session=session)
+    site_capacity_manager = rse_attr.get('site_capacity_manager', None)
+
+    if site_capacity_manager:
+        site_capacity_managers = site_capacity_manager.split(',')
+        if issuer.external in site_capacity_managers:
+            return True
+    return False
 
 
 def perm_set_local_account_limit(issuer, kwargs, session=None):


### PR DESCRIPTION
The script syncs custom roles for capacity managers at CERN [CMS_TIER_0_OPS group in CRIC](https://cms-cric.cern.ch/api/accounts/group/query/?json&name=CMS_TIER_0_OPS).


I have created a general outline. The function can be used as a  skeleton for such site-specific roles. If things tend to be applied more generally, we shall try to add roles for individual users who belong to a particular e-group.

Further, we use the members of this list to provide permissions to set_rse_usage - to set static, and set_rse_limits - to set MinFreeSpace. 

Fix #468 
