### PR TITLE
Using github_env file to pass tag name

### DIFF
--- a/.github/workflows/loadtest-docker-image.yml
+++ b/.github/workflows/loadtest-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
         
       - name: Get tag name
         id: tagname
-        run: echo "::set-output name=tagname::${GITHUB_REF#refs/tags/}"
+        run: echo "tag=${GITHUB_REF#refs/tags/loadtest-}" >> "$GITHUB_ENV"
         
       - name: Login to CERN Harbour
         run: docker login -u ${{ secrets.HARBOR_USERNAME }} -p ${{ secrets.HARBOR_TOKEN }}
@@ -23,10 +23,10 @@ jobs:
         run: |
           docker build . \
           --file docker/CMSRucioClient/Dockerfile.loadtest \
-          --tag registry.cern.ch/${{ secrets.HARBOR_USERNAME }}/rucio-loadtest-client:$${{ steps.tagname.outputs.tagname#loadtest- }}
+          --tag registry.cern.ch/${{ secrets.HARBOR_USERNAME }}/rucio-loadtest-client:${{ env.tag }}
       
       - name: Push Image to CERN Harbour
-        run: docker push registry.cern.ch/${{ secrets.HARBOR_USERNAME }}/rucio-loadtest-client:$${{ steps.tagname.outputs.tagname#loadtest- }} 
+        run: docker push registry.cern.ch/${{ secrets.HARBOR_USERNAME }}/rucio-loadtest-client:${{ env.tag }}
           
           
           


### PR DESCRIPTION
set-output will be deprecated by github in a month. Using the recommend "GITHUB_ENV" file. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


Additional patch for #496 