### PR TITLE
Cmsrucio autoapprove policy updates

### DIFF
--- a/build-rucio-images.sh
+++ b/build-rucio-images.sh
@@ -3,7 +3,7 @@
 set -e
 
 export RUCIO_VERSION=1.31.3
-export CMS_VERSION=${RUCIO_VERSION}.cms5
+export CMS_VERSION=${RUCIO_VERSION}.cms6
 
 export HARBOR=registry.cern.ch/cmsrucio
 

--- a/src/policy/CMSRucioPolicy/schema.py
+++ b/src/policy/CMSRucioPolicy/schema.py
@@ -41,7 +41,7 @@ ACTIVITY = {"description": "Activity name",
                      "Production Input", "Production Output",
                      "Analysis Input", "Analysis Output", "Staging",
                      "T0 Export", "T0 Tape", "Upload/Download (Job)",
-                     "Upload/Download (User)", "User Subscriptions", "Data Challenge"]}
+                     "Upload/Download (User)", "User AutoApprove", "User Subscriptions", "Data Challenge"]}
 
 SCOPE_LENGTH = 25
 


### PR DESCRIPTION
Hi Eric
I thought I had created this PR already. 

This is a tiny update in the auto_approval flow.
- We switched to using the new_activity `User AutoApprove` for auto-approval rules from Data-Brokering
- Added a new limit of 50 TB for rules that target a specific RSE