### PR TITLE
Enable scope creation for local users accounts

### DIFF
--- a/docker/CMSRucioClient/scripts/account_to_scope_mapping.py
+++ b/docker/CMSRucioClient/scripts/account_to_scope_mapping.py
@@ -17,10 +17,12 @@ def add_group_account_scopes(rclient, include_local_users_accounts, only_include
         scope_name = f"group.{account_name}"
         if account_name.endswith("_local_users") or account_name.endswith("_local"):
             if include_local_users_accounts:
-                desired_group_scopes.add((account_name, scope_name))
+                scope_name_short = scope_name.split("_local")[0]
+                desired_group_scopes.add((account_name, scope_name_short))
         elif only_include_accounts_with_group_suffix:
             if account_name.endswith("_group"):
-                desired_group_scopes.add((account_name, scope_name))
+                scope_name_short = scope_name.split("_group")[0]
+                desired_group_scopes.add((account_name, scope_name_short))
         else:
             desired_group_scopes.add((account_name, scope_name))
 

--- a/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
+++ b/docker/CMSRucioClient/scripts/k8s_sync_users_links.sh
@@ -30,7 +30,7 @@ if [ "$RUCIO_HOME" = "/opt/rucio-prod" ]
   echo "Creating user accounts and setting quotas"
   ./user_to_site_mapping.py
   echo "Adding group account scopes"
-  ./account_to_scope_mapping.py --only-include-accounts-with-group-suffix 
+  ./account_to_scope_mapping.py --only-include-accounts-with-group-suffix --include-local-users-accounts
   echo "Syncing custom RSE Roles"
   ./syncCustomRoles.py
 fi


### PR DESCRIPTION
The DB schema places a char limit of 20 for scope length, this we need to trim, `_local_users` and `_group` from local users and physics group accounts.

Fix #531