### PR TITLE
Make set site capacity script configurable

### DIFF
--- a/docker/CMSRucioClient/scripts/setSiteCapacity
+++ b/docker/CMSRucioClient/scripts/setSiteCapacity
@@ -23,8 +23,9 @@ from rucio.common.exception import ConfigNotFound, InvalidRSEExpression
 
 # Set dry_run to True to test the script without updating the static usage
 dry_run = False
+debug = False
 
-if dry_run:
+if debug:
     logging_level = logging.DEBUG
 else:
     logging_level = logging.INFO
@@ -37,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 # Build the opensearch get request
 QUERY_HEADER = '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":["monit_prod_cmssst_*"]}'
+MAX_MIN_FREE_PERCENTAGE = 20.0
+DEFAULT_MIN_FREE_PERCENTAGE = 10.0
 
 try:
     path = os.path.dirname(os.path.realpath(__file__))
@@ -99,8 +102,15 @@ try:
 
     try:
         default_min_free_space_percentage = float(rclient.get_config(section='rses', option='default_min_free_space_percentage'))
+
+        # Preventing accidental setting of min_free_space_percentage to a very high value
+        if default_min_free_space_percentage > MAX_MIN_FREE_PERCENTAGE:
+            raise Exception(f"Invalid default_min_free_space_percentage: {default_min_free_space_percentage}")
     except ConfigNotFound as e:
-        default_min_free_space_percentage = 10.0
+        default_min_free_space_percentage = DEFAULT_MIN_FREE_PERCENTAGE
+    except Exception as e:
+        logger.warn(f"Unexpected value for default_min_free_space_percentage: {e}")
+        default_min_free_space_percentage = DEFAULT_MIN_FREE_PERCENTAGE
     
     rses = [rse['rse'] for rse in rclient.list_rses('cms_type=real&rse_type=DISK')]
     for site in sites :
@@ -124,6 +134,8 @@ try:
         rse_attributes = rclient.list_rse_attributes(rse=rse)
         if 'min_free_space_percentage' in rse_attributes:
             min_free_space_percentage = float(rse_attributes['min_free_space_percentage'])
+            if min_free_space_percentage > MAX_MIN_FREE_PERCENTAGE:
+                min_free_space_bytes = default_min_free_space_percentage
 
         try:
             # Static usage is 0 for many T3s - These are managed as quasi-static
@@ -138,18 +150,26 @@ try:
             else:
                 current_static_usage = current_static_usage[0]['used']
 
-            if current_static_usage == rse_available_bytes:
+            rse_limits = rclient.get_rse_limits(rse=rse)
+            if 'MinFreeSpace' in rse_limits:
+                current_min_free_space = rse_limits['MinFreeSpace']
+            else:
+                current_min_free_space = 0
+            
+            min_free_space_bytes = int(rse_available_bytes*min_free_space_percentage*0.01)
+            # Trigger update on both value and configuraton change
+            if current_static_usage == rse_available_bytes and current_min_free_space == min_free_space_bytes:
                 logger.debug(f"Static usage for {rse} already up to date")
                 continue
 
             if dry_run:
                 logger.info(f"Updating static usage, from {current_static_usage*1e-12:.2f}TB to {rse_available_bytes*1e-12:.2f}TB, for {rse}, dry_run=True")
-                logger.info(f"Updating MinFreeSpace, from {current_static_usage*1e-13:.2f}TB to {rse_available_bytes*1e-13:.2f}TB, for {rse}, dry_run=True")
+                logger.info(f"Updating MinFreeSpace, from {current_min_free_space*1e-12:.2f}TB to {min_free_space_bytes*1e-12:.2f}TB, for {rse}, dry_run=True")
             else:
                 rclient.set_rse_usage(rse=rse, source='static', used=rse_available_bytes, free=None)
-                rclient.set_rse_limits(rse=rse, name='MinFreeSpace', value=rse_available_bytes//min_free_space_percentage)
+                rclient.set_rse_limits(rse=rse, name='MinFreeSpace', value=min_free_space_bytes)
                 logger.info(f"Updating static usage, from {current_static_usage*1e-12:.2f}TB to {rse_available_bytes*1e-12:.2f}TB, for {rse}")
-                logger.info(f"Updating MinFreeSpace, from {current_static_usage*1e-13:.2f}TB to {rse_available_bytes*1e-13:.2f}TB, for {rse}")
+                logger.info(f"Updating MinFreeSpace, from {current_min_free_space*1e-12:.2f}TB to {min_free_space_bytes*1e-12:.2f}TB, for {rse}")
         except Exception as e:
             logger.error(f"Failed to update static usage for {rse}: {e}")
             traceback.print_exc()

--- a/docker/CMSRucioClient/scripts/setSiteCapacity
+++ b/docker/CMSRucioClient/scripts/setSiteCapacity
@@ -7,25 +7,34 @@
 # For more information on what the values mean, refer https://twiki.cern.ch/twiki/bin/view/CMS/SiteSupportDiskSpace
 
 
-import json
 import io
+import json
 import logging
-import requests
 import os
+import requests
+import sys
 import traceback
 
 from datetime import datetime
+from requests.exceptions import ConnectionError
+
 from rucio.client import Client
-
-# configure logging with a custom format
-logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
-
-logger = logging.getLogger(__name__)
+from rucio.common.exception import ConfigNotFound, InvalidRSEExpression
 
 # Set dry_run to True to test the script without updating the static usage
 dry_run = False
 
-SKIP_SITES = []
+if dry_run:
+    logging_level = logging.DEBUG
+else:
+    logging_level = logging.INFO
+
+# configure logging with a custom format
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging_level)
+
+logger = logging.getLogger(__name__)
+
+
 # Build the opensearch get request
 QUERY_HEADER = '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":["monit_prod_cmssst_*"]}'
 
@@ -35,6 +44,7 @@ try:
         lucene = json.load(lucene_json)
 except FileNotFoundError as e:
     logger.error(f'Failed to load lucene query: {e}')
+    sys.exit(1)
 
 # The metric is updated periodically at an interval of 24 hours, and also additionaly on a 30 min interval in case of updates
 time_now = int(datetime.utcnow().timestamp())
@@ -50,37 +60,51 @@ try:
     logger.debug('Querying opensearch')
     r = requests.post('https://monit-grafana.cern.ch/api/datasources/proxy/9475/_msearch', data=query, headers=headers)
     j = json.loads(r.text)
+    if r.status_code != 200:
+        logger.error(f'Failed to query opensearch: {r.status_code} {r.text}')
+        raise ConnectionError
+    if j['responses'][0]['hits']['total'] == 0 or len(j['responses'][0]['hits']['hits']) == 0:
+        logger.error(f'No data found in opensearch')
+        raise Exception("No data found in opensearch")
+    
+    # Filter responses to keep records with highest (latest) metadata.timestamp
+    sites = []
+    for record in j['responses'][0]['hits']['hits']:
+        if record['_source']['data']['name'] not in [site['name'] for site in sites]:
+            new_site = record['_source']['data']
+            new_site['timestamp'] = record['_source']['metadata']['timestamp']
+            sites.append(new_site)
+        else:
+            for site in sites:
+                if site['name'] == record['_source']['data']['name']:
+                    if site['timestamp'] < record['_source']['metadata']['timestamp']:
+                        sites.remove(site)
+                        new_site = record['_source']['data']
+                        new_site['timestamp'] = record['_source']['metadata']['timestamp']
+                        sites.append(new_site)
+
 except Exception as e:
-    logger.error(f'Failed to query opensearch: {e}')
-
-if r.status_code != 200:
-    logger.error(f'Failed to query opensearch: {r.status_code} {r.text}')
-if j['responses'][0]['hits']['total'] == 0 or len(j['responses'][0]['hits']['hits']) == 0:
-    logger.error(f'No data found in opensearch')
-
-# Filter responses to keep records with highest (latest) metadata.timestamp
-sites = []
-for record in j['responses'][0]['hits']['hits']:
-    if record['_source']['data']['name'] not in [site['name'] for site in sites]:
-        new_site = record['_source']['data']
-        new_site['timestamp'] = record['_source']['metadata']['timestamp']
-        sites.append(new_site)
-    else:
-        for site in sites:
-            if site['name'] == record['_source']['data']['name']:
-                if site['timestamp'] < record['_source']['metadata']['timestamp']:
-                    sites.remove(site)
-                    new_site = record['_source']['data']
-                    new_site['timestamp'] = record['_source']['metadata']['timestamp']
-                    sites.append(new_site)
+    logger.error(f'Invalid or No data in OpenSearch, Cannot update site capacity {e}')
+    sys.exit(1)
 
 
 # Update the rucio static usage
 try:
     rclient = Client()
+
+    try:
+        skip_sites = [rse['rse'] for rse in rclient.list_rses(rse_expression='skip_site_capacity_update=True')]
+    except InvalidRSEExpression as e:
+        skip_sites = []
+
+    try:
+        default_min_free_space_percentage = float(rclient.get_config(section='rses', option='default_min_free_space_percentage'))
+    except ConfigNotFound as e:
+        default_min_free_space_percentage = 10.0
+    
     rses = [rse['rse'] for rse in rclient.list_rses('cms_type=real&rse_type=DISK')]
     for site in sites :
-        if site['name'] in SKIP_SITES or f"{site}_Disk" in SKIP_SITES:
+        if site['name'] in skip_sites or f"{site}_Disk" in skip_sites:
             continue
        
         if site['name'] in rses:
@@ -95,6 +119,11 @@ try:
         disk_experiment_use_bytes = site['disk_experiment_use'] * 1e12 #total space used by CMS experiment data
         disk_local_use_bytes = site['disk_local_use'] * 1e12 #additional quota for local rse_local_users account
         rse_available_bytes = disk_experiment_use_bytes + disk_local_use_bytes
+
+        min_free_space_percentage = default_min_free_space_percentage
+        rse_attributes = rclient.list_rse_attributes(rse=rse)
+        if 'min_free_space_percentage' in rse_attributes:
+            min_free_space_percentage = float(rse_attributes['min_free_space_percentage'])
 
         try:
             # Static usage is 0 for many T3s - These are managed as quasi-static
@@ -118,7 +147,7 @@ try:
                 logger.info(f"Updating MinFreeSpace, from {current_static_usage*1e-13:.2f}TB to {rse_available_bytes*1e-13:.2f}TB, for {rse}, dry_run=True")
             else:
                 rclient.set_rse_usage(rse=rse, source='static', used=rse_available_bytes, free=None)
-                rclient.set_rse_limits(rse=rse, name='MinFreeSpace', value=rse_available_bytes//10)
+                rclient.set_rse_limits(rse=rse, name='MinFreeSpace', value=rse_available_bytes//min_free_space_percentage)
                 logger.info(f"Updating static usage, from {current_static_usage*1e-12:.2f}TB to {rse_available_bytes*1e-12:.2f}TB, for {rse}")
                 logger.info(f"Updating MinFreeSpace, from {current_static_usage*1e-13:.2f}TB to {rse_available_bytes*1e-13:.2f}TB, for {rse}")
         except Exception as e:


### PR DESCRIPTION
The script will now be able to configure `static` usage and `MinFreeSpace` limit of a RSE from:
- rse-attributes: 
    - `skip_site_capacity_update`: to not consider rse for update
    - `min_free_space_percentage`: override the default
- rucio config: 
    - `default_min_free_space_percentage` in `rses` section

Additionally, the trigger for updates will be both:
- A change in value in siteCapacity
- A config change for MinFreeSpace percentage as mentioned above