### PR TITLE
Provide site admins permissions to declare replica as bad

### DIFF
--- a/SiteOps/MyRSEs.py
+++ b/SiteOps/MyRSEs.py
@@ -25,7 +25,7 @@ def myrses(account=None):
 
     for r in c.list_rses():
         attributes = c.list_rse_attributes(r['rse'])
-	if ('quota_approvers' in attributes and account in attributes['quota_approvers']) \
+	if ('site_admins' in attributes and account in attributes['site_admins']) \
 	    or ('rule_approvers' in attributes and account in attributes['rule_approvers']):
 	    rses.append(r)
 

--- a/docker/CMSRucioClient/scripts/syncUserRoles.py
+++ b/docker/CMSRucioClient/scripts/syncUserRoles.py
@@ -79,22 +79,15 @@ def set_rse_manager(client, rse_name, site_managers, alt_rse=None):
         alt_rse = alt_rse.lower()
     try:
         client.delete_rse_attribute(rse=rse_name, key='rule_approvers')
-        client.delete_rse_attribute(rse=rse_name, key='quota_approvers')
+        client.delete_rse_attribute(rse=rse_name, key='site_admins')
     except RSEAttributeNotFound:
         pass
-    rule_approvers = ','.join(site_managers[alt_rse])
-    print(f"Setting managers for {rse_name} to {rule_approvers}")
+    site_admins = ','.join(site_managers[alt_rse])
+    print(f"Setting managers for {rse_name} to {site_admins}")
 
-    client.add_rse_attribute(rse=rse_name, key='rule_approvers', value=rule_approvers)
-    # For now, quota approvers are also rule approvers
-    client.add_rse_attribute(rse=rse_name, key='quota_approvers', value=rule_approvers)
-
-    # This is perhaps temporary
-    for account in site_managers[alt_rse]:
-        try:
-            client.add_account_attribute(account=account, key='country-XX', value='admin')
-        except Duplicate:
-            pass
+    client.add_rse_attribute(rse=rse_name, key='rule_approvers', value=site_admins)
+    # For now, site admins are also rule approvers
+    client.add_rse_attribute(rse=rse_name, key='site_admins', value=site_admins)
 
 
 def get_egroup_map(all_groups, tag_relation="facility", role="local-data-manager"):


### PR DESCRIPTION
Fix #526 
Extras
    - Some cleanup of old commented code
    - Change quota approvers to more generic site admins

Documentation for Site Admins: https://cmsdmops.docs.cern.ch/SiteAdmins/Corrupted%20Files/

