### PR TITLE
Set ddm quota as integers

### DIFF
--- a/docker/CMSRucioClient/scripts/updateDDMQuota
+++ b/docker/CMSRucioClient/scripts/updateDDMQuota
@@ -32,9 +32,9 @@ for rse in rses:
     # Normalise
     if static == 0:
         continue
-    
-    ddm_quota = round(max(static - rucio, 0)/static, 4)
-        
+
+    ddm_quota = int((max(static - rucio, 0)/static)*1e4)
+
     # Override ddm_quota for operational purposes
     rse_attributes = client.list_rse_attributes(rse)
     if "override_ddm_quota" in rse_attributes:


### PR DESCRIPTION
CRAB was using these values to select RSEs.
https://github.com/dmwm/CRABServer/issues/7714