### PR TITLE
Get default PNN from SITECONF file

### DIFF
--- a/docker/CMSRucioClient/scripts/cmslinks.py
+++ b/docker/CMSRucioClient/scripts/cmslinks.py
@@ -75,14 +75,16 @@ class LinksMatrix(object):
                     if site.get('rse') in rse:
                         pnn = site.get('site')
                         break
-
-            self.rselist.append({
-                'rse': rse,
-                'pnn': pnn,
-                'type': attrs.get('cms_type'),
-                'country': attrs.get('country'),
-                'region': attrs.get('region', None)
-            })
+            try:
+                self.rselist.append({
+                    'rse': rse,
+                    'pnn': pnn,
+                    'type': attrs.get('cms_type'),
+                    'country': attrs.get('country'),
+                    'region': attrs.get('region')
+                })
+            except Exception as e:
+                logging.warning(f'Could not get attributes for RSE {rse}. Error: {str(e)}')
 
 
     def _get_matrix(self, distance, exclude):

--- a/docker/CMSRucioClient/scripts/cmslinks.py
+++ b/docker/CMSRucioClient/scripts/cmslinks.py
@@ -76,17 +76,14 @@ class LinksMatrix(object):
                         pnn = site.get('site')
                         break
 
-            try:
-                self.rselist.append({
-                    'rse': rse,
-                    'pnn': pnn,
-                    'type': attrs['cms_type'],
-                    'country': attrs['country'],
-                    'region': attrs.get('region', None)
-                })
-            except KeyError:
-                logging.warning('No expected attributes for RSE %s. Skipping',
-                                rse)
+            self.rselist.append({
+                'rse': rse,
+                'pnn': pnn,
+                'type': attrs.get('cms_type'),
+                'country': attrs.get('country'),
+                'region': attrs.get('region', None)
+            })
+
 
     def _get_matrix(self, distance, exclude):
 


### PR DESCRIPTION
Change default PNN value. Modified from None to the `site` attribute from the `SITECONF` file.
Improves link selection by making choose a closer one than in a None value case
FIX: https://github.com/dmwm/CMSRucio/issues/385 