### PR TITLE
Bug: Match rules parser with prefix

### DIFF
--- a/docker/CMSRucioClient/scripts/CMSRSE.py
+++ b/docker/CMSRucioClient/scripts/CMSRSE.py
@@ -458,6 +458,10 @@ class CMSRSE:
                     # if we're here chances are that the prefix didn't have a prefixed "scheme://"
                     logging.debug("couldn't find a scheme when calculating special prefix")
 
+                # Make sure that prefix always ends with "/"
+                if prefix[len(prefix) - 1] != "/":
+                    prefix = prefix + "/"
+
                 proto['prefix'] = prefix
                 # Get rid of the TFC since were are using a prefix but don't get rid
                 # of the web_service_path if it is there

--- a/docker/CMSRucioClient/scripts/CMSRSE.py
+++ b/docker/CMSRucioClient/scripts/CMSRSE.py
@@ -435,9 +435,9 @@ class CMSRSE:
                 for rule in tfc:
                     prefix_regex = re.compile(rule['path'])
                     if self.cms_type == "test":
-                        prefix_match = prefix_regex.match("/store/test/rucio")
+                        prefix_match = prefix_regex.match("/store/test/rucio/")
                     else:
-                        prefix_match = prefix_regex.match("/store/temp")
+                        prefix_match = prefix_regex.match("/store/temp/")
                     if prefix_match:
                         match_rule = rule['path']
                         g1 = prefix_match.group(1)


### PR DESCRIPTION
Match the behavior of "rules" parser with the "prefix" parser
- Update Test / Temp RSE regex
- Force prefix ends with `/`