### PR TITLE
Restrict rse expression to single rse when ask_approval is used

### DIFF
--- a/src/policy/CMSRucioPolicy/permission.py
+++ b/src/policy/CMSRucioPolicy/permission.py
@@ -315,6 +315,10 @@ def perm_add_rule(issuer, kwargs, *, session: "Optional[Session]" = None):
             if rse_attr.get('requires_approval', False):
                 return False
 
+    # If asked for approval, rse_expression can only be a single RSE
+    if kwargs["activity"] != "User AutoApprove" and kwargs["ask_approval"] and len(rses) != 1:
+        return False
+
     if kwargs["activity"] == "User AutoApprove":
         return _check_for_auto_approve_eligibility(issuer, rses, kwargs, session=session)
 


### PR DESCRIPTION
Fixes https://github.com/dmwm/CMSRucio/issues/733