### PR TITLE
Remove 2 probe patches for PR 122 and 123

### DIFF
--- a/docker/rucio-probes/Dockerfile
+++ b/docker/rucio-probes/Dockerfile
@@ -34,12 +34,6 @@ ADD https://raw.githubusercontent.com/nsmith-/probes/hack_replicas/common/check_
 # Supplanted in PR115 ADD https://raw.githubusercontent.com/ericvaandering/probes/cms_check_expired_rules/common/check_expired_rules /probes/common
 ADD https://raw.githubusercontent.com/ericvaandering/probes/cms_check_expired_locked/common/check_expired_locked_rules /probes/common
 
-# PR 122 - Should be in 33.4
-ADD https://raw.githubusercontent.com/ericvaandering/probes/675-dev-merge-and-update-rse-based-probes/cms/check_rse_files_rules /probes/cms/
-
-# PR 123 - Should be in 33.4
-ADD https://raw.githubusercontent.com/Panos512/probes/20240116_combines_space_probes/cms/check_used_space /probes/cms/
-
 # PR 130 - Should be in 33.7
 ADD https://raw.githubusercontent.com/haozturk/probes/720-fix/cms/check_rule_counts /probes/cms/
 


### PR DESCRIPTION
We'll upgrade int to 33.6.1 and these patches are already available in that release