### PR TITLE
Allow non USER datatier in non cms scopes for admin accounts

### DIFF
--- a/src/policy/CMSRucioPolicy/permission.py
+++ b/src/policy/CMSRucioPolicy/permission.py
@@ -574,7 +574,7 @@ def perm_add_did(issuer, kwargs, *, session: "Optional[Session]" = None):
             if rule['account'] != issuer:
                 return False
 
-    if kwargs['scope'].external != u'cms':
+    if kwargs['scope'].external != 'cms' and not has_account_attribute(account=issuer, key='admin', session=session):
         if kwargs['type'] == 'DATASET':
             if '/USER#' not in kwargs['name']:
                 return False
@@ -597,6 +597,8 @@ def perm_add_dids(issuer, kwargs, *, session: "Optional[Session]" = None):
     :param session: The DB session to use
     :returns: True if account is allowed, otherwise False
     """
+    #TODO: Check scope ownership for bulk add operation too
+    
     # Check the accounts of the issued rules
     if not _is_root(issuer) and not has_account_attribute(account=issuer, key='admin', session=session):
         for did in kwargs['dids']:


### PR DESCRIPTION
For now, I am only allowing an admin account for a quick fix to allow wmcore_pileup to carry on its testing but these needs to be thought out and defined clearly.

