### PR TITLE
Upgrade loadtest image to ALMA9

### DIFF
--- a/docker/rucio_client/Dockerfile.loadtest
+++ b/docker/rucio_client/Dockerfile.loadtest
@@ -1,7 +1,3 @@
 FROM registry.cern.ch/cmsrucio/rucio_client:latest
 
 COPY loadtest /loadtest
-
-ENTRYPOINT ["/loadtest/loadtest.py"]
-
-


### PR DESCRIPTION
Fixes #653 

Loadtest image is based on the client image that Dennis upgraded to ALMA9 recently. I've built the most recent version of the new rucio_client image [1,2] and built the loadtest image based on that [3]. The only change I've done was to remove the ENTRYPOINT which is redundant as the process is initiated by the following command defined in the relevant helm chart [4,5]. You can find my tests here [6]


[1] https://github.com/dmwm/CMSRucio/blob/3889a60c6da5ef0f60c4ec184d6a35643aecacfd/docker/rucio_client/Dockerfile 
[2] https://registry.cern.ch/harbor/projects/3667/repositories/rucio_client_hasan/artifacts-tab
[3] https://registry.cern.ch/harbor/projects/3667/repositories/cmsloadtest_hasan/artifacts-tab 
[4] https://github.com/dmwm/CMSRucio/blob/5945331ec29fc2c1629f647fe6174f9819709d01/helm/rucio-loadtest/templates/deployment.yaml#L37 
[5] https://github.com/dmwm/CMSRucio/blob/945f48b9659cdeb06d383e257d00cf7664ba3a58/docker/CMSRucioClient/loadtest/run_loadtest.sh 
[6]
```
$ podman run -d --name loadtest -v "/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security/"  -e RUCIO_HOME='/opt/rucio-prod/' -e SOURCE_EXPRESSION='loadtest=True' -e DEST_EXPRESSION='loadtest=True' -e ACTIVITY='Debug' registry.cern.ch/haozturk/cmsloadtest_hasan:v1
ERRO[0000] cannot find UID/GID for user haozturk: no subuid ranges found for user "haozturk" in /etc/subuid - check rootless mode in man pages. 
WARN[0000] Using rootless single mapping into the namespace. This might break some images. Check /etc/subuid and /etc/subgid for adding sub*ids if not using a network user 
Trying to pull registry.cern.ch/haozturk/cmsloadtest_hasan:v1...
Getting image source signatures
Copying blob a51beb2187bf done  
Copying blob 50f33e9f660f done  
Copying blob 28130cb29ede done  
Copying blob 054f5da23639 done  
Copying blob 428f15592e9d done  
Copying blob 2f6efb13b6ff done  
Copying blob c45e9f831e24 done  
Copying blob 8894ced46fe7 done  
Copying blob e15f129abd3a done  
Copying blob bd88b04c5045 done  
Copying blob abf679e722ef done  
Copying blob 98f651e63aee done  
Copying blob 78a81eb3bf36 done  
Copying blob 8ed62e2f7762 done  
Copying blob 7237e24368d4 done  
Copying blob cd8cd209ebcd done  
Copying blob 35e856b472ae done  
Copying blob 9e5382b18d03 done  
Copying blob 10f1fadcd1e4 done  
Copying blob c52ddfc82e76 done  
Copying config 89beb01b13 done  
Writing manifest to image destination
1b7e03a89c12143407408f1ae09b57851415eab8b022d074c56b9df0460689eb

$ podman cp x509up loadtest:/tmp/
$ podman exec -it loadtest /bin/bash
[root@1b7e03a89c12 ~]# ./loadtest.py -v   --source_rse_expression ${SOURCE_EXPRESSION} --dest_rse_expression ${DEST_EXPRESSION} --activity {ACTIVITY}
bash: ./loadtest.py: No such file or directory
[root@1b7e03a89c12 ~]# cd /loadtest/
[root@1b7e03a89c12 loadtest]# ./loadtest.py -v   --source_rse_expression ${SOURCE_EXPRESSION} --dest_rse_expression ${DEST_EXPRESSION} --activity {ACTIVITY}
2024-04-23 09:16:25,793 __main__:INFO:Link between T2_RU_ITEP and T2_BR_SPRACE with load test rule ee5c30ae3df84abeb2ed01105e638fe3 last updated 21762.793677s ago (target=21600.0), marking destination replicas unavailable
2024-04-23 09:16:25,859 __main__:INFO:No link between T2_RU_ITEP and T1_UK_RAL_Tape, skipping load test
2024-04-23 09:16:25,905 __main__:INFO:No link between T2_RU_ITEP and T0_CH_CERN_Tape, skipping load test
2024-04-23 09:16:26,400 __main__:INFO:No link between T1_RU_JINR_Tape and T1_UK_RAL_Tape, skipping load test
2024-04-23 09:16:26,437 __main__:INFO:No link between T1_RU_JINR_Tape and T0_CH_CERN_Tape, skipping load test
2024-04-23 09:16:26,917 __main__:INFO:No link between T3_US_UMiss and T1_UK_RAL_Tape, skipping load test
2024-04-23 09:16:26,956 __main__:INFO:No link between T3_US_UMiss and T0_CH_CERN_Tape, skipping load test
2024-04-23 09:16:27,386 __main__:INFO:Link between T2_RU_JINR and T2_IN_TIFR with load test rule 9ba3dacad7d9433dbba1ae92fc30bdf7 last updated 22129.386216s ago (target=21600.0), marking destination replicas unavailable
...
```
@ericvaandering 
