### PR TITLE
catch temporary rule creation failed exception

### DIFF
--- a/docker/rucio_client/loadtest/loadtest.py
+++ b/docker/rucio_client/loadtest/loadtest.py
@@ -238,6 +238,12 @@ def update_loadtest(
                 }
             ):
                 client.update_replication_rule(other_rule["id"], {"lifetime": 0})
+        
+        except ReplicationRuleCreationTemporaryFailed as e:
+            logger.error(
+                f"Previous replica has not be deleted from the destination rse {dest_rse} for files in dataset {dataset}", e
+                )
+                
         return False
     if rule["state"] == "SUSPENDED":
         logger.debug(


### PR DESCRIPTION
Loadtests crash when there are problems with deletion at the destination site. 

```
2024-05-10 11:31:59,338 __main__:INFO:New link between T2_EE_Estonia and T2_RU_INR, creating a load test rule this cycle
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "./loadtest.py", line 356, in run
    tape_rses_require_approval
  File "./loadtest.py", line 229, in update_loadtest
    client.add_replication_rule(**rule)
  File "/usr/local/lib/python3.6/site-packages/rucio/client/ruleclient.py", line 91, in add_replication_rule
    raise exc_cls(exc_msg)
rucio.common.exception.ReplicationRuleCreationTemporaryFailed: The creation of the replication rule failed at this time. Please try again later.
Details: (cx_Oracle.IntegrityError) ORA-00001: unique constraint (CMS_RUCIO_PROD.REPLICAS_PK) violated
```