### PR TITLE
Make loadtests be synced from gitlab

### DIFF
--- a/docker/rucio_client/scripts/CMSRSE.py
+++ b/docker/rucio_client/scripts/CMSRSE.py
@@ -62,6 +62,8 @@ class CMSRSE:
         self.settings['deterministic'] = deterministic
         self.rucio_rse_type = json['type'].upper()
 
+        xattrs = {}
+
         # If we are building a _Test or _Temp instance add the special prefix
         if cms_type == "test":
             self.rse_name = json['rse']+"_Test"
@@ -70,11 +72,10 @@ class CMSRSE:
         else:
             self.rse_name = json['rse']
             if json.get('loadtest', None) is not None:
-                self.attrs['loadtest'] = json['loadtest']
+                xattrs['loadtest'] = json['loadtest']
 
-        self._get_attributes()
-        self.attrs['fts'] = ','.join(json['fts'])
-
+        xattrs['fts'] = ','.join(json['fts'])
+        self._get_attributes(xattrs=xattrs)
 
     """
     Parses either a prefix or a pfn within a rule in the storage.json
@@ -246,7 +247,7 @@ class CMSRSE:
         if self.rse_name in APPROVAL_REQUIRED:
             attrs['requires_approval'] = 'True'
 
-        for (key, value) in xattrs:
+        for key, value in xattrs.items():
             attrs[key] = value
 
         self.attrs = attrs
@@ -278,7 +279,6 @@ class CMSRSE:
                                  key, value, self.rse_name)
                 else:
                     self.rcli.add_rse_attribute(rse=self.rse_name, key=key, value=value)
-
         return changed
 
     def _get_protocol(self, proto_json, protos_json):


### PR DESCRIPTION
Fixes #796 

Dry-run is as expected:
```
Checking T2_BR_UERJ and type prod-real
20240510 14:28:44  INFO - setting attribute loadtest to value True for rse T2_BR_UERJ. Dry run, skipping
```


@dynamic-entropy we'd better double check and not merge this on friday. The following lines are concerning 
```
Checking T1_ES_PIC_Disk and type prod-real
20240510 14:27:49  INFO - Deleting davs from T1_ES_PIC_Disk (Dry run, skipping)
20240510 14:27:49  INFO - Deleting srm from T1_ES_PIC_Disk (Dry run, skipping)
20240510 14:27:49  INFO - Deleting root from T1_ES_PIC_Disk (Dry run, skipping)
```
although I see the same lines in the prod logs