### PR TITLE
Add patch for rucio/pull/6444

### DIFF
--- a/docker/rucio-daemons/Dockerfile
+++ b/docker/rucio-daemons/Dockerfile
@@ -27,9 +27,12 @@ RUN rmdir /etc/grid-security/certificates && ln -s /cvmfs/grid.cern.ch/etc/grid-
 ADD docker/rucio-daemons/cms-entrypoint.sh /
 
 # Cannot make patch directory unless there are patches
-#RUN mkdir -p /patch
+RUN mkdir -p /patch
 
 # Patch for auto approve plugin rucio/pull/6215
 #ADD https://github.com/rucio/rucio/pull/6215.patch /patch/6215.patch
+
+# Patch for rucio/pull/6444 to see if it'll fix the issue of conveyor-finisher not marking suspicious replicas
+ADD https://github.com/rucio/rucio/pull/6444.patch /patch/6444.patch 
 
 ENTRYPOINT ["/cms-entrypoint.sh"]


### PR DESCRIPTION
I'd like to test this PR in integration to see if it fixes the issue of conveyor not being able to mark replicas suspicious