### PR TITLE
Add Analysis Tape Recall activity 

### DIFF
--- a/src/policy/CMSRucioPolicy/algorithms/auto_approve.py
+++ b/src/policy/CMSRucioPolicy/algorithms/auto_approve.py
@@ -26,13 +26,15 @@ def global_approval(rule, did, session) -> bool:
     :returns: True if the rule should be auto approved, False otherwise
     """
 
-    auto_approve_activity = 'User AutoApprove'
+    auto_approve_activities = ["User AutoApprove", "Analysis TapeRecall"]
 
     # All checks are performed at rule creation
     # The approval conditions are define in _check_for_auto_approve_eligibility function in the permissions module
     # Check activity is User AutoApprove
+    # Analysis TapeRecall is also auto approved - This is used by CRAB to recall data from tape on behalf of the user
+    # The accounting is handled in crabserver
 
-    if rule['activity'] == auto_approve_activity:
+    if rule["activity"] in auto_approve_activities:
         return True
 
     return False

--- a/src/policy/CMSRucioPolicy/permission.py
+++ b/src/policy/CMSRucioPolicy/permission.py
@@ -322,6 +322,9 @@ def perm_add_rule(issuer, kwargs, *, session: "Optional[Session]" = None):
     if kwargs["activity"] == "User AutoApprove":
         return _check_for_auto_approve_eligibility(issuer, rses, kwargs, session=session)
 
+    if kwargs["activity"] == "Analysis TapeRecall" and issuer.external == "crab_tape_recall":
+        return True
+
     # Anyone can use _Temp RSEs if a lifetime is set and under a month
     all_temp = True
     for rse in rses:

--- a/src/policy/CMSRucioPolicy/schema.py
+++ b/src/policy/CMSRucioPolicy/schema.py
@@ -41,7 +41,9 @@ ACTIVITY = {"description": "Activity name",
                      "Production Input", "Production Output",
                      "Analysis Input", "Analysis Output", "Staging",
                      "T0 Export", "T0 Tape", "Upload/Download (Job)",
-                     "Upload/Download (User)", "User AutoApprove", "User Subscriptions", "Data Challenge"]}
+                     "Upload/Download (User)", "User AutoApprove",
+                     "User Subscriptions", "Data Challenge", "Analysis TapeRecall"]}
+
 
 SCOPE_LENGTH = 25
 


### PR DESCRIPTION
This activity can only be used by the `crab_tape_recall` account.

For https://github.com/dmwm/CRABServer/issues/8354