### PR TITLE
Add replica recoverer daemon config in the policy package

### DIFF
--- a/src/policy/CMSRucioPolicy/daemonsConfig/suspicious_replica_recoverer.json
+++ b/src/policy/CMSRucioPolicy/daemonsConfig/suspicious_replica_recoverer.json
@@ -1,0 +1,12 @@
+[
+    {
+        "action": "ignore",
+        "datatype": ["RAW"],
+        "scope": []
+    },
+    {
+        "action": "declare bad",
+        "datatype": [],
+        "scope": []
+    }
+]


### PR DESCRIPTION
replica recoveror daemon requires a json file for its configuration [1]. I don't know what's the best way to get this file into the image. Since policy package is already copied into the image and it's the place for cms specific policy, I've put it there. @ericvaandering @dynamic-entropy if you think that this is not the right place, I can put it elsewhere in the repo and update the dockerfile to copy it specifically. Please let me know


[1] https://github.com/rucio/rucio/blob/730e0f555a8496bf2ad7aef7d84ed699dfcb4466/lib/rucio/daemons/replicarecoverer/suspicious_replica_recoverer.py#L586 