### PR TITLE
Sync int rses

### DIFF
--- a/.github/workflows/rucio-release-images.yml
+++ b/.github/workflows/rucio-release-images.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build the Docker Image
         run: |
-          buildah build --build-arg RUCIO_VERSION=${{ env.rucio_version }} --file docker/${{ matrix.image }}/Dockerfile --tag registry.cern.ch/${{ vars.HARBOR_REPOSITORY }}/${{ matrix.image }}:${{ env.tag }} .
+          buildah build --build-arg RUCIO_VERSION=${{ env.rucio_version }} --build-arg CMSRUCIO_GITTAG=${{ env.tag }} --file docker/${{ matrix.image }}/Dockerfile --tag registry.cern.ch/${{ vars.HARBOR_REPOSITORY }}/${{ matrix.image }}:${{ env.tag }} .
 
       - name: Push the Docker Image
         run: |

--- a/docker/rucio_client/Dockerfile
+++ b/docker/rucio_client/Dockerfile
@@ -1,6 +1,7 @@
 FROM almalinux:9
 
 ARG RUCIO_VERSION
+ARG CMSRUCIO_GITTAG
 
 RUN dnf upgrade -y && \
     dnf clean all && \
@@ -58,6 +59,7 @@ RUN git clone https://github.com/rucio/rucio.git
 # Pull some useful stuff out of git
 WORKDIR /root
 RUN git clone https://github.com/dmwm/CMSRucio.git
+RUN cd CMSRucio && git checkout $CMSRUCIO_GITTAG
 
 RUN mkdir -p /etc/grid-security ; ln -s /cvmfs/grid.cern.ch/etc/grid-security/certificates /etc/grid-security/
 

--- a/docker/rucio_client/scripts/CMSRSE.py
+++ b/docker/rucio_client/scripts/CMSRSE.py
@@ -19,8 +19,8 @@ DOMAINS_BY_TYPE = {
                 'delete': 1},
         'lan': {'read': 0, 'write': 0, 'delete': 0}},
     'int-real': {
-        'wan': {'read': 1, 'write': 0, 'third_party_copy_write': 1, 'third_party_copy_read': 1,
-                'delete': 0},
+        'wan': {'read': 1, 'write': 1, 'third_party_copy_write': 1, 'third_party_copy_read': 1,
+                'delete': 1},
         'lan': {'read': 0, 'write': 0, 'delete': 0}},
     'test': {
         'wan': {'read': 1, 'write': 1, 'third_party_copy_write': 1, 'third_party_copy_read': 1,
@@ -355,6 +355,9 @@ class CMSRSE:
             # if we are building a _Test instance add the specia prefix
             if self.cms_type == "test":
                 prefix = prefix + "store/test/rucio/"
+
+            elif self.cms_type == "int-real":
+                prefix = prefix + "store/test/rucio/int/"
 
             elif self.cms_type == "temp":
                 prefix = prefix + "store/temp/"

--- a/docker/rucio_client/scripts/k8s_sync_sites.sh
+++ b/docker/rucio_client/scripts/k8s_sync_sites.sh
@@ -11,7 +11,6 @@ voms-proxy-init -voms cms  -cert /tmp/cert.pem -key /tmp/key.pem
 voms-proxy-info
 
 cd /root/CMSRucio
-git pull origin master
 export RUCIO_ACCOUNT=root
 
 echo Using config file in $RUCIO_HOME
@@ -23,6 +22,8 @@ set -x
 cd docker/rucio_client/scripts/
 if [ "$RUCIO_HOME" = "/opt/rucio-int" ]
   then
+  echo "Syncing Integration sites from JSON"
+  ./setRucioFromGitlab --type int-real 
   exit 0
 fi
 


### PR DESCRIPTION
This PR updates cron job scripts to sync RSE protocol from GitLab on the integration server.

Additionaly, to enable testing it, modifies the docker commands to checkout the CMSRucio repo at appropriate tag for the rucio client.

Fixes https://github.com/dmwm/CMSRucio/issues/765