### PR TITLE
Fix deprecated package name gfal2-util

### DIFF
--- a/docker/rucio_client/Dockerfile
+++ b/docker/rucio_client/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf config-manager --save --setopt=wlcg.skip_if_unavailable=true \
     && dnf install -y which krb5-devel gridsite \
     globus-proxy-utils voms-clients-cpp wlcg-voms-cms \
     wlcg-iam-vomses-cms \
-    gfal2-util gfal2-all gfal2-plugin-xrootd python3-gfal2 && \
+    python3-gfal2-util gfal2-all python3-gfal2 && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
The latest release of Gfal2-util (v1.9.0) removed the `Provides: gfal2-util`

Gfal2 package now only provides: `python3-gfal2` and `python3-gfal2-util`

Additionally, removing `gfal2-plugin-xrootd`, since its already bundled with `gfal2-all`.