### PR TITLE
Update siteAvailability script according to the new rucio status

### DIFF
--- a/docker/rucio_client/scripts/availability_lucene.json
+++ b/docker/rucio_client/scripts/availability_lucene.json
@@ -35,7 +35,8 @@
       "metadata.kafka_timestamp",
       "data.name",
       "data.status",
-      "data.prod_status"
+      "data.prod_status",
+      "data.rucio_status"
     ]
   },
   "size": 10000,

--- a/docker/rucio_client/scripts/setSiteAvailability
+++ b/docker/rucio_client/scripts/setSiteAvailability
@@ -60,8 +60,8 @@ for site in sites:
             continue  # Until we get good metrics for Tier3s
         if rse in available_map:
             continue
-        ssb_status = site.get('status', None)
-        if not ssb_status or ssb_status != 'enabled':
+        rucio_status = site.get('rucio_status', None)
+        if not rucio_status or rucio_status not in ['dependable', 'enabled']:
             available_map[rse] = False
         else:
             available_map[rse] = True


### PR DESCRIPTION
Fixes #828 

Based on Rucio status in [1]

I realized that we're not updating `availability_read`. @dynamic-entropy how about disabling `availability_read` if rucio status is one of `downtime_stop`, `parked`, `disabled`?

@stlammel fyi

[1] https://twiki.cern.ch/twiki/bin/view/CMS/SiteSupportSiteStatusSiteReadiness 