### PR TITLE
patch for json serialisation for empty dirs

### DIFF
--- a/docker/rucio-daemons/Dockerfile
+++ b/docker/rucio-daemons/Dockerfile
@@ -38,4 +38,7 @@ RUN mkdir -p /patch
 ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/1.patch /patch/1.patch
 ADD https://patch-diff.githubusercontent.com/raw/ericvaandering/rucio/pull/10.patch /patch/10.patch
 
+# Patch for get-rse-info command for tapes
+# Most probably not needed here at all, json serialisation should not be needed in daemons
+ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/3.patch /patch/3.patch
 ENTRYPOINT ["/cms-entrypoint.sh"]

--- a/docker/rucio-server/Dockerfile
+++ b/docker/rucio-server/Dockerfile
@@ -30,4 +30,7 @@ RUN mkdir -p /patch
 ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/1.patch /patch/1.patch
 ADD https://patch-diff.githubusercontent.com/raw/ericvaandering/rucio/pull/10.patch /patch/10.patch
 
+# Patch for get-rse-info command for tapes
+ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/3.patch /patch/3.patch
+
 ENTRYPOINT ["/cms-entrypoint.sh"]

--- a/docker/rucio-ui/Dockerfile
+++ b/docker/rucio-ui/Dockerfile
@@ -22,10 +22,13 @@ RUN rm -f /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/userdir.conf /etc/htt
 ENV RUCIO_CA_PATH="/cvmfs/grid.cern.ch/etc/grid-security/certificates"
 
 # Cannot make patch directory unless there are patches
-#RUN mkdir -p /patch
+RUN mkdir -p /patch
 
 # Patch for auto approve plugin rucio/pull/6215
 #ADD https://github.com/rucio/rucio/pull/6215.patch /patch/6215.patch
+
+# Patch for get-rse-info command for tapes
+ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/3.patch /patch/3.patch
 
 ADD docker/rucio-ui/cms-entrypoint.sh /
 ENTRYPOINT ["/cms-entrypoint.sh"]


### PR DESCRIPTION
@Panos512 reported a failed `get_rse_info` after upgrading to rucio 35. 

```
 ✘ ppaparri@lxplus942  ~  rucio-admin rse info T0_CH_CERN_Tape
An unknown exception occurred.
Details: no error information passed (http status code: 500)
Rucio exited with an unexpected/unknown error, please provide the traceback below to the developers.
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/rucio/x86_64/rhel9/py3/current/bin/rucio-admin", line 97, in new_funct
    return function(*args, **kwargs)
  File "/cvmfs/cms.cern.ch/rucio/x86_64/rhel9/py3/current/bin/rucio-admin", line 533, in info_rse
    rse_limits = client.get_rse_limits(args.rse)
  File "/cvmfs/cms.cern.ch/rucio/x86_64/rhel9/py3/current/lib/python3.9/site-packages/rucio/client/rseclient.py", line 569, in get_rse_limits
    raise exc_cls(exc_msg)
rucio.common.exception.RucioException: An unknown exception oc
```


This is a regression from https://github.com/rucio/rucio/issues/6598

An upstream bug and a fix to be followed.