### PR TITLE
Patch rucio 7106 which is a fix of rucio 7105

### DIFF
--- a/docker/rucio-daemons/Dockerfile
+++ b/docker/rucio-daemons/Dockerfile
@@ -41,4 +41,7 @@ ADD https://patch-diff.githubusercontent.com/raw/ericvaandering/rucio/pull/10.pa
 # Patch for get-rse-info command for tapes
 # Most probably not needed here at all, json serialisation should not be needed in daemons
 ADD https://patch-diff.githubusercontent.com/raw/dynamic-entropy/rucio/pull/3.patch /patch/3.patch
+
+# To be removed once this PR is available in our rucio version
+ADD https://patch-diff.githubusercontent.com/raw/rucio/rucio/pull/7106.patch /patch/7106.patch
 ENTRYPOINT ["/cms-entrypoint.sh"]


### PR DESCRIPTION
In the scope of https://github.com/dmwm/CMSRucio/issues/806 patching https://github.com/rucio/rucio/pull/7106 which is a fix to https://github.com/rucio/rucio/issues/7105

This is needed to be able to run replica recoverer properly finally and give feedback in the rucio workshop ideally.