### PR TITLE
update rucio-consistency helm chart for adding prometheus monitoring

### DIFF
--- a/helm/rucio-consistency/Chart.yaml
+++ b/helm/rucio-consistency/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/rucio-consistency/templates/deployment.yaml
+++ b/helm/rucio-consistency/templates/deployment.yaml
@@ -46,6 +46,22 @@ spec:
                   key: db_ro_string
             - name: RUCIO_CFG_DATABASE_SCHEMA
               value: {{ .Values.consistency.schema }}
+            - name: PROMETHEUS_SERVERS
+              value: {{ .Values.consistency.prometheus_servers }}
+            - name: PROMETHEUS_PREFIX
+              value: {{ .Values.consistency.prometheus_prefix }}
+            - name: PROMETHEUS_LABELS
+              value: {{ .Values.consistency.prometheus_labels }}
+            - name: RUCIO_HOST
+              value: {{ .Values.consistency.rucio_host }}
+            - name: AUTH_HOST
+              value: {{ .Values.consistency.auth_host }}
+            - name: AUTH_TYPE
+              value: {{ .Values.consistency.auth_type }}
+            - name: CA_CERT
+              value: {{ .Values.consistency.ca_cert }}
+            - name: REQUEST_RETRIES
+              value: {{ .Values.consistency.request_retries }}                                                                                             
           command: ["/consistency/run.sh"]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/rucio-consistency/values.yaml
+++ b/helm/rucio-consistency/values.yaml
@@ -17,6 +17,14 @@ jobber:
       data: [stdout, stderr]
 
 consistency:
+  prometheus_servers: ""
+  prometheus_prefix: ""
+  prometheus_labels: ""
+  rucio_host: ""
+  auth_host: ""
+  auth_type: ""
+  ca_cert: ""
+  request_retries: ""
   schema: "CMS_RUCIO_PROD"
   logLevel: "INFO"
   scratchSize: 100Gi


### PR DESCRIPTION
This PR is a duplicate of https://github.com/dmwm/CMSRucio/pull/844, providing additional changes and merging into master as requested.

The PR includes a new version of rucio-consistency helm chart. The new chart adds some environment variables that will be used for prometheus.