### PR TITLE
Set dm_weight to 0 if a site's usage is above its quota or its availability_write is False

### DIFF
--- a/docker/rucio_client/scripts/updateDDMQuota
+++ b/docker/rucio_client/scripts/updateDDMQuota
@@ -36,12 +36,12 @@ def get_sum_of_all_rse_statics(rse_expression):
     rses = [rse["rse"] for rse in client.list_rses(rse_expression=rse_expression)]
     result = 0
     for rse in rses:
-        static, _, _ = get_rse_info(rse)
+        static, _, _ = get_rse_usage(rse)
         result += static
     return result
 
 
-def get_rse_info(rse):
+def get_rse_usage(rse):
     rse_usage = list(client.get_rse_usage(rse))
 
     required_fields = {"static", "rucio", "expired"}
@@ -69,18 +69,36 @@ def calculate_dm_weights(rse_expression, static_weight, free_weight, expired_wei
     dm_weights = {}
 
     for rse in rses:
-        static, rucio, expired = get_rse_info(rse)
+        static, rucio, expired = get_rse_usage(rse)
 
         # Normalise
         if static == 0:
             continue  # Skip if static is 0
 
+        free = static - rucio
+
         # Control dm_weight for specially configured rses
         rse_attributes = client.list_rse_attributes(rse)
+        rse_settings = client.get_rse(rse)
 
-        free = static - rucio
-        dm_weight = static_weight * (static / total_static) + free_weight * \
-            (free / static) + expired_weight * (expired / static)
+        # dm_weight should be zero if site is over the quota or
+        # availability_write is False
+        set_dm_weight_to_0 = False
+        try:
+            availability_write = rse_settings['availability_write']
+            if availability_write == False:
+                set_dm_weight_to_0 = True
+            if free < 0:
+                set_dm_weight_to_0 = True
+        except Exception as e:
+            # If availability_write setting doesn't exist, dm weight should be 0
+            set_dm_weight_to_0 = True
+        
+        if set_dm_weight_to_0:
+            dm_weight = 0
+        else:
+            dm_weight = static_weight * (static / total_static) + free_weight * \
+                (free / static) + expired_weight * (expired / static)
         dm_weight_coefficient = 1
         if "dm_weight_coefficient" in rse_attributes:
             dm_weight_coefficient = float(rse_attributes["dm_weight_coefficient"])
@@ -93,7 +111,6 @@ def calculate_dm_weights(rse_expression, static_weight, free_weight, expired_wei
             "free": free,
             "dm_weight_coefficient" : dm_weight_coefficient,
         }
-
         dm_weights[rse] = dm_weight
     return dm_weights
 


### PR DESCRIPTION
Fixes #877 

Sets the dm_weight to 0 if a site's usage is above its quota or its `availability_write` is False.

I ran it manually and the result is as expected:
```
[haozturk@lxplus960 scripts]$ python3 updateDDMQuota 
Set dm_weight for T2_UK_SGrid_RALPP to 13
Set dm_weight for T2_IT_Bari to 13
Set dm_weight for T2_UK_London_IC to 30
Set dm_weight for T1_UK_RAL_Disk to 67
Set dm_weight for T2_IT_Rome to 0
Set dm_weight for T2_TR_METU to 0
Set dm_weight for T1_IT_CNAF_Disk to 57
Set dm_weight for T2_BR_UERJ to 0.0
Set dm_weight for T2_DE_RWTH to 8
Set dm_weight for T2_FI_HIP to 2
Set dm_weight for T2_RU_ITEP to 35
Set dm_weight for T2_TW_NCHC to 0
Set dm_weight for T2_KR_KISTI to 7
Set dm_weight for T2_IN_TIFR to 0
Set dm_weight for T2_UK_SGrid_Bristol to 0
Set dm_weight for T2_ES_IFCA to 16
Set dm_weight for T2_ES_CIEMAT to 37
Set dm_weight for T2_CH_CSCS to 20
Set dm_weight for T2_US_Florida to 12
Set dm_weight for T1_ES_PIC_Disk to 100
Set dm_weight for T2_AT_Vienna to 19
Set dm_weight for T2_HU_Budapest to 22
Set dm_weight for T2_EE_Estonia to 13
Set dm_weight for T1_RU_JINR_Disk to 95
Set dm_weight for T1_DE_KIT_Disk to 35
Set dm_weight for T2_RU_IHEP to 0.0
Set dm_weight for T1_FR_CCIN2P3_Disk to 31
Set dm_weight for T2_US_Purdue to 8
Set dm_weight for T2_US_Nebraska to 2
Set dm_weight for T1_US_FNAL_Disk to 13
Set dm_weight for T2_PK_NCP to 0
Set dm_weight for T2_FR_GRIF_LLR to 0
Set dm_weight for T2_FR_GRIF_IRFU to 0
Set dm_weight for T2_UA_KIPT to 20
Set dm_weight for T2_RU_INR to 0
Set dm_weight for T2_LB_HPC4L to 0
Set dm_weight for T2_BR_SPRACE to 32
Set dm_weight for T2_US_UCSD to 1
Set dm_weight for T2_US_Vanderbilt to 12
Set dm_weight for T2_CN_Beijing to 3
Set dm_weight for T2_PT_NCG_Lisbon to 15
Set dm_weight for T2_CH_CERN to 32
Set dm_weight for T2_FR_IPHC to 0
Set dm_weight for T2_BE_IIHE to 11
Set dm_weight for T2_PL_Swierk to 33
Set dm_weight for T2_FR_GRIF to 65
Set dm_weight for T2_US_Caltech to 12
Set dm_weight for T2_US_Wisconsin to 2
Set dm_weight for T2_DE_DESY to 22
Set dm_weight for T2_IT_Pisa to 64
Set dm_weight for T2_UK_London_Brunel to 4
Set dm_weight for T2_BE_UCL to 14
Set dm_weight for T2_IT_Legnaro to 16
Set dm_weight for T2_RU_JINR to 25
Set dm_weight for T2_PL_Cyfronet to 0
Set dm_weight for T2_US_MIT to 7
Set dm_weight for T1_UK_RAL_Tape to 1
Set dm_weight for T1_ES_PIC_Tape to 1
Set dm_weight for T1_FR_CCIN2P3_Tape to 19
Set dm_weight for T1_IT_CNAF_Tape to 100
Set dm_weight for T1_DE_KIT_Tape to 12
Set dm_weight for T2_US_MIT_Tape to 25
RSE                    PLEDGE (PB)    FREE SPACE (PB)    RELATIVE FREE (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
-------------------  -------------  -----------------  -------------------  -----------------------  -----------
T2_UK_SGrid_RALPP           1.8            0.0903115              5.0173                          1           13
T2_IT_Bari                  4.35           0.536865              12.3417                          1           13
T2_UK_London_IC             6.3            0.336041               5.33398                         1           30
T1_UK_RAL_Disk              7.693          0.563426               7.32388                         1           67
T2_IT_Rome                  2.35           0.161761               6.88345                         1            0
T2_TR_METU                  0.925          0.0588462              6.36175                         1            0
T1_IT_CNAF_Disk            10              0.957486               9.57486                         1           57
T2_BR_UERJ                  0.39           0.304711              78.131                           0            0
T2_DE_RWTH                  3.3825         0.306423               9.05908                         1            8
T2_FI_HIP                   2.175          0.125523               5.77119                         1            2
T2_RU_ITEP                  0.231          0.0119353              5.1668                          1           35
T2_TW_NCHC                  0.7            0.0706421             10.0917                          1            0
T2_KR_KISTI                 1.8            0.127036               7.05755                         1            7
T2_IN_TIFR                  5.75           0.678522              11.8004                          1            0
T2_UK_SGrid_Bristol         0.4            0.03193                7.9825                          1            0
T2_ES_IFCA                  0.7            0.0380473              5.43534                         1           16
T2_ES_CIEMAT                4.85           0.24258                5.00166                         1           37
T2_CH_CSCS                  3.58           0.184097               5.14238                         1           20
T2_US_Florida               4.52           0.473606              10.478                           1           12
T1_ES_PIC_Disk              5              1.62849               32.5698                          1          100
T2_AT_Vienna                0.5            0.0479216              9.58431                         1           19
T2_HU_Budapest              1.55           0.0784397              5.06062                         1           22
T2_EE_Estonia               1.38           0.152476              11.049                           1           13
T1_RU_JINR_Disk            10.6            0.627211               5.91708                         1           95
T1_DE_KIT_Disk             10.93           0.708532               6.48245                         1           35
T2_RU_IHEP                  0.3            0.0704921             23.4974                          0            0
T1_FR_CCIN2P3_Disk         11.8            0.741991               6.28806                         1           31
T2_US_Purdue                5              0.501371              10.0274                          1            8
T2_US_Nebraska              4.4505         0.222487               4.99914                         1            2
T1_US_FNAL_Disk            46.95           2.54826                5.42761                         1           13
T2_PK_NCP                   0.401          0.218931              54.5962                          1            0
T2_FR_GRIF_LLR              1.532          1.52925               99.8205                          1            0
T2_FR_GRIF_IRFU             1.3            1.29757               99.8129                          1            0
T2_UA_KIPT                  1              0.0540211              5.40211                         1           20
T2_RU_INR                   0.24          -1.43567             -598.195                           1            0
T2_LB_HPC4L                 0.09           0.00961258            10.6806                          1            0
T2_BR_SPRACE                2              0.105519               5.27596                         1           32
T2_US_UCSD                  3.435          0.0584824              1.70254                         1            1
T2_US_Vanderbilt           13.2            1.07018                8.10746                         1           12
T2_CN_Beijing               0.55           0.0316663              5.75752                         1            3
T2_PT_NCG_Lisbon            0.6            0.0312175              5.20291                         1           15
T2_CH_CERN                 32              2.04769                6.39902                         1           32
T2_FR_IPHC                  2.2           -0.432147             -19.643                           1            0
T2_BE_IIHE                  4.992          0.282695               5.66295                         1           11
T2_PL_Swierk                1.4            0.114905               8.2075                          1           33
T2_FR_GRIF                  4.05           0.479457              11.8384                          1           65
T2_US_Caltech               4.4            0.346361               7.87183                         1           12
T2_US_Wisconsin             3.9            0.196989               5.05099                         1            2
T2_DE_DESY                  7.8            0.949479              12.1728                          1           22
T2_IT_Pisa                  4.4            0.237565               5.39921                         1           64
T2_UK_London_Brunel         0.8            0.0577211              7.21514                         1            4
T2_BE_UCL                   3.425          0.312338               9.11936                         1           14
T2_IT_Legnaro               4.35           0.218326               5.01899                         1           16
T2_RU_JINR                  1.57           0.00343211             0.218606                        1           25
T2_PL_Cyfronet              0.4            0.0228466              5.71165                         1            0
T2_US_MIT                   5.53           0.277123               5.01127                         1            7
RSE                   PLEDGE (PB)    FREE SPACE (PB)    RELATIVE FREE (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
------------------  -------------  -----------------  -------------------  -----------------------  -----------
T1_UK_RAL_Tape             24.424           1.27789               5.23211                      1              1
T1_ES_PIC_Tape             17.2             1.61802               9.4071                       1              1
T1_FR_CCIN2P3_Tape         39.9             1.26265               3.16455                      1             19
T1_IT_CNAF_Tape            54.4            12.0925               22.2288                       1            100
T1_DE_KIT_Tape             38               0.733834              1.93114                      1             12
T2_US_MIT_Tape              3               1.14186              38.0621                       0.7           25
```
@Panos512 @ericvaandering 