### PR TITLE
availability_read set available automatically

### DIFF
--- a/docker/rucio_client/scripts/setSiteAvailability
+++ b/docker/rucio_client/scripts/setSiteAvailability
@@ -71,7 +71,7 @@ print("Skipping RSEs: %s" % skip_rses)
 for rse, available in available_map.items():
     try:
         if not DRY_RUN:
-            rclient.update_rse(rse, {"availability_write": available, "availability_delete": available})
+            rclient.update_rse(rse, {"availability_write": available, "availability_delete": available, "availability_read": available})
         print('Setting availability for %s to %s' % (rse, available))
     except Exception as e:  # Should never be the case
         print('Failed to update RSE %s, Error %s' % (rse, e))


### PR DESCRIPTION
When RSE's availability is updated, the flag availability_read should be set automatically, similar to current availability_write and availability_delete

Relevant issue: https://github.com/dmwm/CMSRucio/issues/883