### PR TITLE
Metadata Plugin Initialization Correction

### DIFF
--- a/src/policy/CMSRucioPolicy/__init__.py
+++ b/src/policy/CMSRucioPolicy/__init__.py
@@ -3,9 +3,10 @@
 # Eric Vaandering <ewv@fnal.gov>, 2022
 
 from CMSRucioPolicy.algorithms import lfn2pfn, auto_approve, pfn2lfn
-
+from CMSRucioPolicy.algorithms.tape_collocation import CMSTapeCollocation
 SUPPORTED_VERSION = [">= 36.0"]
 
+CMSTapeCollocation._module_init_()
 
 def get_algorithms():
     """


### PR DESCRIPTION
- Reworking the way initialization is done. (Should avoid recursive import errors, but I can't say for sure. Worth testing out in int for *sure*)
- Makes most functions static or class methods to compile with the requirements of the policy package `register` method. (Putting in a similar documentation issue shortly on rucio/docs, none of this explained.)
- Forces everything to use the CMS scope and throws a DID error otherwise instead of verifying after doing a bunch of operations. 