### PR TITLE
Changing import order to avoid circular imports in policy packages

### DIFF
--- a/src/policy/CMSRucioPolicy/__init__.py
+++ b/src/policy/CMSRucioPolicy/__init__.py
@@ -2,16 +2,15 @@
 #
 # Eric Vaandering <ewv@fnal.gov>, 2022
 
-from CMSRucioPolicy.algorithms import lfn2pfn, auto_approve, pfn2lfn
-from CMSRucioPolicy.algorithms.tape_collocation import CMSTapeCollocation
 SUPPORTED_VERSION = [">= 36.0"]
 
-CMSTapeCollocation._module_init_()
 
 def get_algorithms():
     """
     Get the algorithms for the policy package
     """
+    from CMSRucioPolicy.algorithms import lfn2pfn, auto_approve, pfn2lfn
+    from CMSRucioPolicy.algorithms.tape_collocation import CMSTapeCollocation
     return {
         'lfn2pfn': {
             'cmstfc': lfn2pfn.cmstfc,
@@ -21,5 +20,9 @@ def get_algorithms():
         },
         'pfn2lfn': {
             'cms_pfn2lfn': pfn2lfn.cms_pfn2lfn,
+        }, 
+        "fts3_tape_metadata_plugins": {
+            "tape_collocation": CMSTapeCollocation,
         }
     }
+

--- a/src/policy/CMSRucioPolicy/algorithms/tape_collocation.py
+++ b/src/policy/CMSRucioPolicy/algorithms/tape_collocation.py
@@ -23,10 +23,11 @@ class CMSTapeCollocation(FTS3TapeMetadataPlugin):
 
         super().__init__(self.policy_algorithm)
 
-        logger.info("Initialized plugin 'Tape Collocation'")
+        logger.info("Initialized plugin %s", self.policy_algorithm)
 
     @classmethod
     def _module_init_(cls) -> None:
+        logger.info("Registered plugin %s", cls.policy_algorithm)
         cls.register(
             cls.policy_algorithm, 
             func= lambda x: cls._collocation(cls.cms_collocation, x), 
@@ -162,3 +163,5 @@ class CMSTapeCollocation(FTS3TapeMetadataPlugin):
             logger.debug("Could not determine data type for %s", lfn)
 
         return collocation
+
+CMSTapeCollocation._module_init_()


### PR DESCRIPTION
Initialization of the plugin was failing due to circular imports - solved by moving imports inside `get_algorithms()`. 
Circular import was because when importing the original policy, the config is needed for `FTS3TapeMetadataPlugin` subclasses,  but the schema in the policy package is required to pick up the config. 

This isn't caught in dev instances because they all use a default schema.