### PR TITLE
helm chart for dmtops subscription monitoring cron

### DIFF
--- a/helm/rucio-cron-jobs/templates/cronjobs.yaml
+++ b/helm/rucio-cron-jobs/templates/cronjobs.yaml
@@ -123,3 +123,47 @@ spec:
 {{- end }}
               command: ['/root/CMSRucio/docker/rucio_client/scripts/k8s_sync_users_links.sh']
           restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rucio-subscriptions
+  namespace: {{ .Values.dmops_namespace }}
+spec:
+  schedule: "0 6 * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            app: dmtops-spark-svc
+        spec:
+          volumes:
+          - name: dmtops-cron-secrets
+            secret:
+              secretName: dmtops-cron-secrets
+          containers:
+            - name: rucio-subscriptions
+              image: "{{ .Values.dmops_image.repository }}:{{ .Values.dmops_image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.dmops_image.pullPolicy }}
+              volumeMounts:
+                - name: dmtops-cron-secrets
+                  mountPath: /etc/secrets
+                  readOnly: true
+              env:
+                - name: DRIVERPORT
+                  value: "31203"
+                - name: BMPORT
+                  value: "31204"
+                - name: K8SHOST
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+              ports:
+                - containerPort: 31203 # spark.driver.port
+                  name: port-0
+                - containerPort: 31204 # spark.driver.blockManager.port
+                  name: port-1
+              command: ['/src/submit_rucio_subscriptions.sh']
+          restartPolicy: OnFailure

--- a/helm/rucio-cron-jobs/templates/services.yaml
+++ b/helm/rucio-cron-jobs/templates/services.yaml
@@ -1,0 +1,22 @@
+# Services used to open node ports for Spark communications
+# WARNING: The same ports can't be used in parallel for different spark-jobs
+kind: Service
+apiVersion: v1
+metadata:
+  name: dmtops-spark-svc
+  namespace: {{ .Values.dmops_namespace }}
+spec:
+  selector:
+    app: dmtops-spark-svc
+  type: NodePort
+  ports:
+    - name: port-0 # spark.driver.port
+      nodePort: 31203
+      port: 31203
+      protocol: TCP
+      targetPort: 31203
+    - name: port-1 # spark.driver.blockManager.port
+      nodePort: 31204
+      port: 31204
+      protocol: TCP
+      targetPort: 31204

--- a/helm/rucio-cron-jobs/values.yaml
+++ b/helm/rucio-cron-jobs/values.yaml
@@ -10,6 +10,14 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
+dmops_image:
+  repository: registry.cern.ch/cmsrucio/dmops-spark-crons
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+dmops_namespace: "dmtops-crons"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This is a first shot in porting one of the dmops crons from int to helm/flux as described in #904 

I've also thought of adding a new namespace to host all those dmops crons in one place.

I think after we make sure these changes are valid and we merge them we would only then need the secret created to properly run the cron from the production cluster.
@ericvaandering  Do we have some special way of managing the secrets or should I manually create the secret in the production cluster? 

