### PR TITLE
Excluded Tape RSEs from switch off site availability based on  occupancy

### DIFF
--- a/docker/rucio_client/scripts/setSiteAvailability
+++ b/docker/rucio_client/scripts/setSiteAvailability
@@ -76,8 +76,8 @@ for site in sites:
                 "availability_delete": True
             }
 
-        # If the site is enabled based on SSB, do an occupancy check
-        if available_map[rse]:
+        # If the site is not tape and is enabled based on SSB, do an occupancy check
+        if available_map[rse] and not '_Tape' in rse:
             should_enable = should_enable_availability_on_occupancy(rse)
             if not should_enable:
                 print(f"{rse} doesn't have enough free space. Writing will be disabled.")


### PR DESCRIPTION
Based on [1], we don't want to switch off availability write for tapes based on occupancy. Rather, if a tape site has more than 98%, the production output rule creation is managed by `wmcore_output_tape` attribute [2] and we will inform T0 to stop rule creation to that specific site (in the near future, we would like this to be done automatically as well). This will help us manage stuck/suspended rules which are trying to transfer files to the site since we will tackle the actual issue instead of the RSE excluded from writing such as [3].


[1] https://github.com/dmwm/rucio-flux/pull/399
[2] https://github.com/dmwm/CMSRucio/blob/master/docker/rucio_client/scripts/setWmcoreTapeOutput
[3] https://its.cern.ch/jira/browse/CMSDM-319