### PR TITLE
Make `dm_weight`s sum up to 100 and improve reporting

### DIFF
--- a/docker/rucio_client/scripts/updateDDMQuota
+++ b/docker/rucio_client/scripts/updateDDMQuota
@@ -8,7 +8,7 @@ client = Client()
 # See the following link for documentation and please update it if you change the logic
 # https://cmsdmops.docs.cern.ch/Operators/ManageDMWeight/
 
-DRY_RUN = True
+DRY_RUN = False
 TOTAL_DM_WEIGHT = 100
 stats = {}
 


### PR DESCRIPTION
Previously weights were hard to interpret, because they were integers between 0 and 100 but they didn't sum up to 100. 
- This PR makes the weights sum up 100, so that weight of each RSE shows with which percentage the RSE is likely to be chosen.
- Secondly, I've made the the reporting easier to read by sorting the results and adding all the parameters affecting the calculation.
- Thirdly, previously free space was equal to `static - rucio`, but now it's equal to `static-rucio-minFreeSpace`. This way, minFreeSpace isn't treated as free space that can increase the weight, but rather as if it's occupied space.
- Lastly, I've adjusted the weights of the static, free and expired variables.
The table looked previously as [1]
Now it looks as [2]

@ericvaandering @Panos512 @juanpablosalas @eachristgr FYI
[1]
```
RSE                    PLEDGE (PB)    FREE SPACE (PB)    RELATIVE FREE (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
-------------------  -------------  -----------------  -------------------  -----------------------  -----------
T2_KR_KISTI                 1.8            0.120777                6.70982                      1             11
T2_ES_CIEMAT                5.75           0.462998                8.05214                      1             21
T1_DE_KIT_Disk             14.28           0.845657                5.92197                      1             25
T1_PL_NCBJ_Disk             1.4            0.121166                8.6547                       1             35
T2_UK_London_Brunel         0.8            0.107846               13.4807                       1             27
T1_RU_JINR_Disk            10.6            1.07278                10.1206                       1             93
T2_IN_TIFR                  5.75           0.678518               11.8003                       1              0
T2_CN_Beijing               0.55           0.0375639               6.8298                       1              1
T2_FI_HIP                   2.175          0.180723                8.30912                      1             23
T2_FR_GRIF                  4.487          0.367117                8.18179                      1              0
T2_PL_Cyfronet              0.4            0.028136                7.034                        1              5
T2_HU_Budapest              1.55           0.134328                8.66631                      1             30
T1_IT_CNAF_Disk            17.7            0.895604                5.05991                      1             16
T2_US_Vanderbilt           13.2            0.680833                5.15783                      1              2
T2_US_UCSD                  4.035          0.236235                5.85466                      1             18
T2_IT_Rome                  3.85           0.450721               11.7071                       1              0
T2_US_Nebraska              4.924          0.251125                5.10003                      1             10
T2_CH_CSCS                  3.58           0.188915                5.27694                      1             13
T2_US_Purdue                5.3            0.532422               10.0457                       1             14
T2_PT_NCG_Lisbon            0.6            0.0406964               6.78273                      1             13
T2_BR_UERJ                  0.39           0.216915               55.6191                       0              0
T2_US_Wisconsin             5              0.267515                5.3503                       1              2
T2_BE_UCL                   3.476          0.24854                 7.15016                      1             14
T2_FR_IPHC                  2.66           0.672013               25.2637                       1             78
T2_FR_GRIF_LLR              1.532          1.53052                99.9037                       1              0
T2_TR_METU                  0.925          0.0588448               6.3616                       1              0
T2_EE_Estonia               1.38           0.0826617               5.98998                      1              0
T2_IT_Bari                  5.85           0.450826                7.70643                      1             14
T2_US_Florida               4.87           0.56939                11.6918                       1             17
T1_US_FNAL_Disk            63.95           9.55416                14.94                         0.8           29
T2_RU_INR                   0.24          -0.0357582             -14.8992                       1              0
T1_UK_RAL_Disk              9.394          0.763262                8.12499                      1             14
T2_TW_NCHC                  0.7            0.04661                 6.65857                      1              0
T2_LB_HPC4L                 0.155          0.00994346              6.41514                      1              6
T2_CH_CERN                 42.5            8.50083                20.0019                       1             46
T2_BR_SPRACE                2              0.10033                 5.01648                      1              1
T2_IT_Pisa                  5.261          0.482874                9.17836                      1             85
T2_ES_IFCA                  0.7            0.0378115               5.40164                      1              0
T2_UK_SGrid_Bristol         0.4            0.0172186               4.30466                      1              0
T2_AT_Vienna                0.5            0.131912               26.3824                       1             31
T1_FR_CCIN2P3_Disk         14.11           0.724748                5.13641                      1             22
T2_RU_IHEP                  0.3            0.0737833              24.5944                       0              0
T2_LV_HPCNET                0.21           0.0328032              15.6206                       1             12
T2_RU_ITEP                  0.231          0.0176738               7.65102                      1              0
T2_PK_NCP                   0.401          0.218931               54.5962                       1              0
T2_UA_KIPT                  1              0.132549               13.2549                       1             25
T2_DE_RWTH                  3.3825         0.217775                6.43829                      1              4
T2_UK_London_IC             6.3            0.643785               10.2188                       1              8
T2_US_Caltech               5.4            0.379513                7.02802                      1             19
T2_US_MIT                   4.91           0.245505                5.0001                       1             10
T2_IT_Legnaro               4.35           0.364601                8.38163                      1             12
T2_RU_JINR                  1.57           0.399059               25.4178                       1            100
T2_FR_GRIF_IRFU             1.3            1.29843                99.8789                       1              0
T2_DE_DESY                  9.5            0.923858                9.72482                      1             13
T1_ES_PIC_Disk              5.95           0.952105               16.0018                       1             41
T2_UK_SGrid_RALPP           1.8            0.284577               15.8098                       1             14
T2_BE_IIHE                  4.992          0.266045                5.32943                      1              8
RSE                PLEDGE (PB)    FREE SPACE (PB)    RELATIVE FREE (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
---------------  -------------  -----------------  -------------------  -----------------------  -----------
T2_US_MIT_Tape          12                1.6778              13.9816                         1            1
T1_UK_RAL_Tape          29.438            2.33534              7.93308                        1           31
T2_DE_DESY_Tape          3                1.9255              64.1833                         1           93
T1_ES_PIC_Tape          20.025            2.10008             10.4873                         1           12
T1_RU_JINR_Tape         25               10.5966              42.3866                         1          100
```
[2]
```
RSE                    PLEDGE (PB)    FREE SPACE (PB)    EXPIRED SPACE (PB)    RELATIVE PLEDGE (%)    RELATIVE FREE (%)    RELATIVE EXPIRED (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
-------------------  -------------  -----------------  --------------------  ---------------------  -------------------  ----------------------  -----------------------  -----------
T1_RU_JINR_Disk            10.6           0.542779              6.05805                  3.30919            5.12055                57.1514                           1      12.1793
T2_IT_Pisa                  5.261         0.219824              2.98666                  1.64242            4.17836                56.7698                           1      10.9655
T2_RU_JINR                  1.57          0.320559              0.567227                 0.490134          20.4178                 36.1291                           1       9.94201
T1_US_FNAL_Disk            63.95          6.35666              11.1747                  19.9644             9.94005                17.4741                           0.8     4.76293
T1_PL_NCBJ_Disk             1.4           0.0511658             0.474134                 0.437062           3.6547                 33.8667                           1       4.05262
T1_DE_KIT_Disk             14.28          0.131657              4.1552                   4.45803            0.921967               29.098                            1       3.39655
T2_HU_Budapest              1.55          0.0568277             0.472599                 0.48389            3.66631                30.4903                           1       3.38839
T2_FR_IPHC                  2.66          0.140013              0.734597                 0.830418           5.26366                27.6164                           1       3.27316
T1_FR_CCIN2P3_Disk         14.11          0.019248              3.99705                  4.40496            0.136414               28.3278                           1       3.06906
T2_UK_London_Brunel         0.8           0.0678455             0.167619                 0.24975            8.48069                20.9524                           1       2.63166
T2_FI_HIP                   2.175         0.0719733             0.573215                 0.679007           3.30912                26.3547                           1       2.60968
T2_ES_CIEMAT                5.75          0.175486              1.39065                  1.79508            3.05193                24.1853                           1       2.41687
T2_US_Caltech               5.4           0.109501              1.33273                  1.68581            2.0278                 24.6801                           1       2.28469
T1_IT_CNAF_Disk            17.7           0.0106042             3.98178                  5.52572            0.0599106              22.4959                           1       2.28467
T2_US_UCSD                  4.035         0.0344198             1.06133                  1.25968            0.853032               26.3031                           1       2.24631
T2_CH_CERN                 42.5           0.0024533             5.50514                 13.268              0.00577246             12.9533                           1       2.19528
T1_ES_PIC_Disk              5.95          0.0596054             1.45186                  1.85751            1.00177                24.401                            1       2.08817
T2_AT_Vienna                0.5           0.106912              0.0103746                0.156094          21.3824                  2.07493                          1       2.00859
T1_UK_RAL_Disk              9.394         0.293415              1.64402                  2.93269            3.12343                17.5008                           1       1.63806
T2_BE_UCL                   3.476         0.074674              0.714478                 1.08516            2.14827                20.5546                           1       1.60631
T2_IT_Bari                  5.85          0.158318              1.11088                  1.8263             2.70629                18.9893                           1       1.59976
T2_CH_CSCS                  3.58          0.00991455            0.809616                 1.11763            0.276943               22.615                            1       1.5951
T2_UA_KIPT                  1             0.0325487             0.196327                 0.312187           3.25487                19.6327                           1       1.53672
T2_PT_NCG_Lisbon            0.6           0.0106964             0.127305                 0.187312           1.78273                21.2176                           1       1.50099
T2_DE_DESY                  9.5           0.448731              1.34304                  2.96578            4.72349                14.1372                           1       1.44937
T2_US_Nebraska              4.924         0.00492548            0.988415                 1.53721            0.10003                20.0734                           1       1.31174
T2_IT_Legnaro               4.35          0.147101              0.712984                 1.35801            3.38163                16.3904                           1       1.30417
T2_US_MIT                   4.91          5.10408e-06           0.988183                 1.53284            0.000103953            20.1259                           1       1.3035
T2_KR_KISTI                 1.8           0.0307767             0.330538                 0.561937           1.70982                18.3632                           1       1.19854
T2_UK_SGrid_RALPP           1.8           0.194577              0.118819                 0.561937          10.8098                  6.60104                          1       1.07143
T2_BE_IIHE                  4.992         0.0164449             0.8768                   1.55844            0.329425               17.5641                           1       1.06052
T2_US_Florida               4.87          0.082255              0.729971                 1.52035            1.68901                14.9891                           1       0.952546
T2_UK_London_IC             6.3           0.328785              0.590002                 1.96678            5.21881                 9.36511                          1       0.855
T2_US_Purdue                5.3           0.00242178            0.799302                 1.65459            0.0456939              15.0812                           1       0.790418
T2_LB_HPC4L                 0.155         0.00219346            0.0222399                0.048389           1.41514                14.3484                           1       0.699708
T2_DE_RWTH                  3.3825        0.0486501             0.392933                 1.05597            1.43829                11.6167                           1       0.572772
T2_PL_Cyfronet              0.4           0.00813602            0.0468415                0.124875           2.034                  11.7104                           1       0.549548
T2_US_Vanderbilt           13.2           0.0208332             1.01594                  4.12087            0.157827                7.6965                           1       0.436979
T2_US_Wisconsin             5             0.0175151             0.517661                 1.56094            0.350303               10.3532                           1       0.429756
T2_LV_HPCNET                0.21          0.0118032             0.0118255                0.0655593          5.62055                 5.63121                          1       0.408308
T2_CN_Beijing               0.55          0.0100639             0.0331149                0.171703           1.8298                  6.02089                          1       0.189516
T2_BR_SPRACE                2             0.000329604           0.130605                 0.624375           0.0164802               6.53023                          1       0.143769
T2_IN_TIFR                  5.75          0.391018              4.79078                  1.79508            6.80031                83.3179                           1       0
T2_IT_Rome                  3.85          0.258221              2.03644                  1.20192            6.70705                52.8946                           1       0
T2_BR_UERJ                  0.39          0.197415              0.0961138                0.121753          50.6191                 24.6446                           0       0
T2_TW_NCHC                  0.7           0.01161               0.506619                 0.218531           1.65857                72.3741                           1       0
T2_FR_GRIF_IRFU             1.3           1.23343               1.38129e-05              0.405844          94.8789                  0.00106253                       1       0
T2_ES_IFCA                  0.7           0.00281146            0.194538                 0.218531           0.401637               27.7912                           1       0
T2_RU_ITEP                  0.231         0.00612385            0.159914                 0.0721153          2.65102                69.2269                           1       0
T2_TR_METU                  0.925         0.0125948             0.746                    0.288773           1.3616                 80.6486                           1       0
T2_FR_GRIF                  4.487         0.142767              1.48189                  1.40078            3.18179                33.0263                           1       0
T2_RU_IHEP                  0.3           0.0587833             0.171991                 0.0936562         19.5944                 57.3304                           0       0
T2_UK_SGrid_Bristol         0.4          -0.00278137            0.242141                 0.124875          -0.695342               60.5352                           1       0
T2_FR_GRIF_LLR              1.532         1.45392               1.28761e-05              0.478271          94.9037                  0.000840474                      1       0
T2_PK_NCP                   0.401         0.198881              0.182054                 0.125187          49.5962                 45.3999                           1       0
T2_RU_INR                   0.24         -0.0477582             1.11635e-05              0.074925         -19.8992                  0.00465147                       1       0
T2_EE_Estonia               1.38          0.0136617             0.400177                 0.430819           0.98998                28.9983                           1       0
RSE                PLEDGE (PB)    FREE SPACE (PB)    EXPIRED SPACE (PB)    RELATIVE PLEDGE (%)    RELATIVE FREE (%)    RELATIVE EXPIRED (%)    DM WEIGHT COEFFICIENT    DM_WEIGHT
---------------  -------------  -----------------  --------------------  ---------------------  -------------------  ----------------------  -----------------------  -----------
T1_RU_JINR_Tape         25               10.5966              2.57613                 27.9445              42.3866                10.3045                          1      29.4307
T2_DE_DESY_Tape          3                1.9255              0.0496357                3.35334             64.1833                 1.65452                         1      28.2614
T1_UK_RAL_Tape          29.438            2.33534             0.0923019               32.9052               7.93308                0.313547                        1      17.0892
T1_ES_PIC_Tape          20.025            2.10008             0.240379                22.3836              10.4873                 1.2004                          1      13.7551
T2_US_MIT_Tape          12                1.6778              0.12262                 13.4134              13.9816                 1.02184                         1      11.4637
```