### PR TITLE
updated integration RSEs injection scripts

### DIFF
--- a/src/IntSetupRSEs.py
+++ b/src/IntSetupRSEs.py
@@ -163,7 +163,7 @@ def main():
 
 
 
-    input_rses = set(RSES_TO_SET+RSES_INPUT)
+    input_rses = set(RSES_INPUT)
     write_rses = set(RSES_TO_SET)
 
     for rse_name in set(RSES_TO_SET+RSES_INPUT):


### PR DESCRIPTION
These are the updated scripts used to transfer a production dataset to the integration cluster [1] in a recent ticket. This scripts are also the basis for the outline of the procedure at  [2].

[1] https://its.cern.ch/jira/browse/CMSTRANSF-1260
[2] https://cmsdmops.docs.cern.ch/Handbook/IntegrationTransfer/