### PR TITLE
Enhance logging and enable user RSE handling in setSiteCapacity

### DIFF
--- a/docker/rucio_client/scripts/k8s_sync_sites.sh
+++ b/docker/rucio_client/scripts/k8s_sync_sites.sh
@@ -35,6 +35,7 @@ fi
 
 ./setRucioFromGitlab --type test
 ./setRucioFromGitlab --type temp
+./setRucioFromGitlab --type user
 
 echo "Set site capacity"
 ./setSiteCapacity

--- a/docker/rucio_client/scripts/setSiteCapacity
+++ b/docker/rucio_client/scripts/setSiteCapacity
@@ -137,13 +137,15 @@ try:
                     rclient.set_rse_usage(rse=tape_rse, source='static', used=tape_usable_bytes, free=None)
                     logger.info(f"Updating static usage, from {current_static_usage*1e-12:.2f}TB to {tape_usable_bytes*1e-12:.2f}TB, for {tape_rse}")
 
+        # logger.info(f"{rses}")
         # Update static usage for Disks
         if site['name'] in rses:
             rse = site['name']
-        if f"{site['name']}_User" in rses:
-            rse = f"{site['name']}_User"
         elif f"{site['name']}_Disk" in rses:
             rse = f"{site['name']}_Disk"
+        elif f"{site['name']}_User" in rses:
+            logger.info("User RSE")
+            rse = f"{site['name']}_User"
         else:
             logger.debug(f"RSE {site['name']} or {site['name']}_Disk not a valid RSE")
             continue
@@ -152,10 +154,10 @@ try:
         rses_to_update = [rse]
 
         # Also process _User variant if it exists
-        if not rse.startswith("T1") and not rse.endswith("_Tape"):
-          user_rse = f"{rse}_User"
-          if user_rse in rses:
-            rses_to_update.append(user_rse)
+        #if not rse.startswith("T1") and not rse.endswith("_Tape"):
+        #  user_rse = f"{rse}_User"
+        #  if user_rse in rses:
+        #    rses_to_update.append(user_rse)
 
         for rse in rses_to_update:
             logger.info(f"Updating {rse}")

--- a/docker/rucio_client/scripts/setSiteCapacity
+++ b/docker/rucio_client/scripts/setSiteCapacity
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-# This script updates the rucio static usage for a given site reading values from 
+# This script updates the rucio static usage for a given site reading values from
 # scap15min index in CMSMONIT Opensearch
 # It is meant to be run as a cronjob
 # Site admins can modify the values from https://cmssst.web.cern.ch/cgi-bin/set/SiteCapacity
@@ -140,6 +140,8 @@ try:
         # Update static usage for Disks
         if site['name'] in rses:
             rse = site['name']
+        if f"{site['name']}_User" in rses:
+            rse = f"{site['name']}_User"
         elif f"{site['name']}_Disk" in rses:
             rse = f"{site['name']}_Disk"
         else:
@@ -148,13 +150,15 @@ try:
 
         # Process main RSE
         rses_to_update = [rse]
-        
+
         # Also process _User variant if it exists
-        user_rse = f"{rse.replace('_Disk', '')}_User"
-        if user_rse in rses:
+        if not rse.startswith("T1") and not rse.endswith("_Tape"):
+          user_rse = f"{rse}_User"
+          if user_rse in rses:
             rses_to_update.append(user_rse)
 
         for rse in rses_to_update:
+            logger.info(f"Updating {rse}")
             if rse in skip_rses:
                 logger.debug(f"Skipping static usage update for {rse}")
                 continue
@@ -162,9 +166,10 @@ try:
             logger.debug(f"Updating static usage for {rse}")
             disk_experiment_use_bytes = site['disk_experiment_use'] * 1e12 #total space used by CMS experiment data
             disk_local_use_bytes = site['disk_local_use'] * 1e12 #additional quota for local rse_local_users account
-            
+
             # For _User suffix RSEs, the entire capacity comes from disk_local_use
             if rse.endswith('_User'):
+                logger.info(f"_User ending. quota {disk_local_use_bytes}")
                 rse_available_bytes = disk_local_use_bytes
             else:
                 rse_available_bytes = disk_experiment_use_bytes + disk_local_use_bytes
@@ -187,7 +192,7 @@ try:
                     skip_check = disk_local_use_bytes == 0
                 else:
                     skip_check = disk_experiment_use_bytes == 0
-                
+
                 if skip_check:
                     logger.debug(f"Static usage for {rse} is 0, skipping")
                     continue
@@ -228,5 +233,3 @@ try:
 except Exception as e:
     logger.error(f'Failed to connect to rucio: {e}')
     traceback.print_exc()
-
-

--- a/docker/rucio_client/scripts/setSiteCapacity
+++ b/docker/rucio_client/scripts/setSiteCapacity
@@ -137,7 +137,6 @@ try:
                     rclient.set_rse_usage(rse=tape_rse, source='static', used=tape_usable_bytes, free=None)
                     logger.info(f"Updating static usage, from {current_static_usage*1e-12:.2f}TB to {tape_usable_bytes*1e-12:.2f}TB, for {tape_rse}")
 
-        # logger.info(f"{rses}")
         # Update static usage for Disks
         if site['name'] in rses:
             rse = site['name']
@@ -152,12 +151,6 @@ try:
 
         # Process main RSE
         rses_to_update = [rse]
-
-        # Also process _User variant if it exists
-        #if not rse.startswith("T1") and not rse.endswith("_Tape"):
-        #  user_rse = f"{rse}_User"
-        #  if user_rse in rses:
-        #    rses_to_update.append(user_rse)
 
         for rse in rses_to_update:
             logger.info(f"Updating {rse}")

--- a/docker/rucio_client/scripts/syncUserRoles.py
+++ b/docker/rucio_client/scripts/syncUserRoles.py
@@ -8,7 +8,7 @@ from rucio.client.client import Client
 from rucio.common.exception import RSEAttributeNotFound, Duplicate, AccountNotFound, InvalidObject, DatabaseException
 from legacydn_converter import rfc2253dn
 
-TO_STRIP = ['_Disk', '_Tape', '_Temp', '_Disk_Temp', '_Test', '_Disk_Test', '_Tape_Test', '_Ceph']
+TO_STRIP = ['_Disk', '_Tape', '_Temp', '_Disk_Temp', '_Test', '_Disk_Test', '_Tape_Test', '_Ceph', '_User']
 
 CRIC_USERS_API = 'https://cms-cric.cern.ch/api/accounts/user/query/list/?json&preset=roles'
 CRIC_SITE_API = 'https://cms-cric.cern.ch/api/cms/site/query/?json'


### PR DESCRIPTION
Updates the site capacity synchronization scripts to better handle RSEs with a `_User` suffix and adds logging for improved traceability. This will enable creation of `T2_IT_Rome_User`

* The `setSiteCapacity` script now explicitly checks for and handles RSEs with a `_User` suffix when updating site capacities, ensuring these are included in the update process.
* When an RSE ends with `_User`, the script sets its available capacity based solely on `disk_local_use`, reflecting its intended usage from sitecapacity.

**Script invocation and workflow updates:**

* The `k8s_sync_sites.sh` script now calls `setRucioFromGitlab` with the `--type user` argument, ensuring user-type RSEs are synchronized.

Here the output from integration:
```
$ rucio rse show T2_IT_Rome_User
Settings:
=========
  availability: 7
  availability_delete: True
  availability_read: True
  availability_write: True
  credentials: None
  deterministic: True
  domain: ['lan', 'wan']
  id: 7c75b6ec472344cd8e67d9b82771ca4b
  lfn2pfn_algorithm: cmstfc
  qos_class: None
  rse: T2_IT_Rome_User
  rse_type: DISK
  sign_url: None
  staging_area: False
  verify_checksum: True
  volatile: False
Attributes:
===========
  T2_IT_Rome_User: True
  cms_type: user
  country: IT
  fts: https://fts3-cms.cern.ch:8446,https://cmsfts3.fnal.gov:8446
  lfn2pfn_algorithm: cmstfc
  tier: 2
Protocols:
==========
  davs
    domains: '{"lan": {"read": null, "write": null, "delete": null}, "wan": {"read": 1, "write": 1, "delete": 1, "third_party_copy_read": 1, "third_party_copy_write": 1}}'
    extended_attributes: {'tfc_proto': 'webdav', 'tfc': [{'proto': 'webdav', 'path': '/+store(.*)', 'out': 'davs://cmsrm-webdav.roma1.infn.it:2880/$1'}]}
    hostname: cmsrm-webdav.roma1.infn.it
    impl: rucio.rse.protocols.gfal.Default
    port: 2880
    prefix: /
    scheme: davs
Usage:
======
  expired
    files: 0
    free: None
    rse: T2_IT_Rome_User
    rse_id: 7c75b6ec472344cd8e67d9b82771ca4b
    source: expired
    total: 0
    updated_at: 2026-06-17 11:11:42
    used: 0
  obsolete
    files: 0
    free: None
    rse: T2_IT_Rome_User
    rse_id: 7c75b6ec472344cd8e67d9b82771ca4b
    source: obsolete
    total: 0
    updated_at: 2026-06-17 11:11:07
    used: 0
  rucio
    files: 0
    free: None
    rse: T2_IT_Rome_User
    rse_id: 7c75b6ec472344cd8e67d9b82771ca4b
    source: rucio
    total: 0
    updated_at: 2026-06-17 06:36:39
    used: 0
  static
    files: None
    free: None
    rse: T2_IT_Rome_User
    rse_id: 7c75b6ec472344cd8e67d9b82771ca4b
    source: static
    total: 70000000000000
    updated_at: 2026-06-17 11:14:53
    used: 70000000000000
RSE limits:
===========
  MinFreeSpace: 7000000000000 B
  ```