### PR TITLE
file-integrity-check: validate that LFNs are .root files

### DIFF
--- a/DMOps/file-integrity-check/generic-decompression-check/src/run_check.py
+++ b/DMOps/file-integrity-check/generic-decompression-check/src/run_check.py
@@ -49,6 +49,11 @@ def check_files(
             lfn = lfn_with_scope
             logger.warning(f"No scope provided for '{lfn}'. Using default scope 'cms'.")
 
+        if not lfn.endswith('.root'):
+            logger.error(f"The LFN provided is not a .root file: '{lfn_with_scope}'")
+            results.append({"filename": lfn_with_scope, "error": "The LFN provided is not a .root file."})
+            continue
+
         file_result = {"filename": lfn_with_scope, "replicas": []}
 
         try:

--- a/DMOps/file-integrity-check/generic-decompression-check/src/test.py
+++ b/DMOps/file-integrity-check/generic-decompression-check/src/test.py
@@ -43,10 +43,18 @@ if __name__ == "__main__":
         "/store/mc/RunIISummer16NanoAODv5/CITo2Mu_M800_CUETP8M1_Lam16TeVDesLL_13TeV_Pythia8_Corrected-v3/NANOAODSIM/PUMoriond17_Nano1June2019_102X_mcRun2_asymptotic_v7-v1/30000/8BB32229-E898-B445-B871-4FC2840B46D5.root"
     ]
 
-    print("\nTesting check_files - no rse_expression.")
+    print("\n3. Testing check_files - non-.root LFN (should be rejected).")
+    non_root_lfns = ["cms:/store/data/Run2024/dataset", "/store/data/Run2024/block"]
+    results = check_files(non_root_lfns, workdir="./tmp")
+    print(json.dumps(results))
+    for r in results:
+        assert r.get('error') == "The LFN provided is not a .root file.", f"Unexpected result: {r}"
+    print("Test 3. completed. Non-.root LFNs correctly rejected.")
+
+    print("\n4. Testing check_files - no rse_expression.")
     results = check_files(test_lfns, workdir="./tmp")
     print(json.dumps(results))
 
-    print("\nTesting check_files - with rse_expression.")
+    print("\n5. Testing check_files - with rse_expression.")
     results = check_files(test_lfns, workdir="./tmp", rse_expression="rse_type=DISK")
     print(json.dumps(results))

--- a/DMOps/file_invalidation_server/file_integrity_checker/serializers.py
+++ b/DMOps/file_invalidation_server/file_integrity_checker/serializers.py
@@ -35,11 +35,11 @@ class FileIntegrityRequestSerializer(serializers.Serializer):
 
     def validate_lfns(self, value):
         lines = [l.strip() for l in value.splitlines() if l.strip()]
-        
+
         # Check for duplicates
         if len(lines) != len(set(lines)):
             raise serializers.ValidationError("Duplicate LFNs provided.")
-        
+
         if not lines:
             raise serializers.ValidationError("No LFNs provided.")
 
@@ -47,6 +47,16 @@ class FileIntegrityRequestSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 f"Too many LFNs: {len(lines)} provided, "
                 f"maximum is {MAX_LFNS_PER_REQUEST}."
+            )
+
+        non_root = [
+            l for l in lines
+            if not (l.split(':', 1)[-1] if ':' in l else l).endswith('.root')
+        ]
+        if non_root:
+            raise serializers.ValidationError(
+                f"The LFN(s) provided are not .root files. "
+                f"Invalid entries: {non_root}"
             )
 
         return lines

--- a/DMOps/file_invalidation_server/file_integrity_checker/tests.py
+++ b/DMOps/file_invalidation_server/file_integrity_checker/tests.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from .models import FileIntegrityRequest, FileReplica
 from .tasks import process_integrity_check, split_scope, FileIntegrityRequest
 from .views import derive_file_status, build_request_summary, _format_lfns_per_rse
+from .serializers import FileIntegrityRequestSerializer
 from file_integrity_checker.process_jobs import parse_tool_output, update_replicas
 from file_integrity_checker.process_queue import process_queue, MAX_CONCURRENT_JOBS
 
@@ -29,6 +30,36 @@ class SplitScopeTest(TestCase):
             split_scope('T2_CH_CERN:/store/file.root'),
             ('T2_CH_CERN', '/store/file.root')
         )
+
+
+class FileIntegrityRequestSerializerTest(TestCase):
+
+    def test_root_lfn_accepted(self):
+        serializer = FileIntegrityRequestSerializer(data={'lfns': 'cms:/store/data/Run2024/file.root'})
+        self.assertTrue(serializer.is_valid())
+
+    def test_non_root_lfn_rejected(self):
+        serializer = FileIntegrityRequestSerializer(data={'lfns': 'cms:/store/data/Run2024/dataset'})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('lfns', serializer.errors)
+
+    def test_non_root_lfn_error_message(self):
+        serializer = FileIntegrityRequestSerializer(data={'lfns': 'cms:/store/data/Run2024/dataset'})
+        serializer.is_valid()
+        error_msg = ' '.join(str(e) for e in serializer.errors['lfns'])
+        self.assertIn('The LFN(s) provided are not .root files', error_msg)
+        self.assertIn('cms:/store/data/Run2024/dataset', error_msg)
+
+    def test_non_root_lfn_without_scope_rejected(self):
+        serializer = FileIntegrityRequestSerializer(data={'lfns': '/store/data/Run2024/dataset'})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('lfns', serializer.errors)
+
+    def test_mixed_root_and_non_root_rejected(self):
+        lfns = 'cms:/store/data/Run2024/file.root\ncms:/store/data/Run2024/dataset'
+        serializer = FileIntegrityRequestSerializer(data={'lfns': lfns})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('lfns', serializer.errors)
 
 
 class ProcessIntegrityCheckTest(TestCase):
@@ -447,6 +478,15 @@ class ViewEndpointTest(TestCase):
             lfn='/store/data/file2.root',
             rse='T1_US_FNAL_Disk', status='CORRUPTED'
         )
+
+    def test_submit_non_root_lfn_returns_400(self):
+        r = self.client.post(
+            '/api/integrity/submit/',
+            data={'lfns': 'cms:/store/data/Run2024/dataset'},
+        )
+        self.assertEqual(r.status_code, 400)
+        data = r.json()
+        self.assertIn('lfns', data)
 
     def test_query_list_returns_200(self):
         r = self.client.get('/api/integrity/query/requests/')

--- a/DMOps/file_invalidation_server/file_integrity_checker/views.py
+++ b/DMOps/file_invalidation_server/file_integrity_checker/views.py
@@ -343,7 +343,7 @@ class FileIntegrityQueryRequestView(APIView):
             if self.request.accepted_renderer.format == 'html':
                 return render(self.request, self.detail_template, {'data':response_data})
             else:
-                return Response(result, status=status.HTTP_200_OK)
+                return Response(response_data, status=status.HTTP_200_OK)
 
         # --- List view ---
         requests_qs = FileIntegrityRequest.objects.all()


### PR DESCRIPTION
Both the run_check.py script and the server serializer now reject LFNs that do not end in '.root', preventing containers and blocks from being passed to the integrity checker. A pre-existing UnboundLocalError in the request detail JSON view (result vs response_data) is also fixed.