### PR TITLE
File invalidation server: Approval permissions based on GMS API

### DIFF
--- a/DMOps/file_invalidation_server/fi_manager/utils.py
+++ b/DMOps/file_invalidation_server/fi_manager/utils.py
@@ -12,6 +12,7 @@ from django.core.mail import send_mail
 from django.conf import settings
 from jira import JIRA
 from enum import Enum
+import requests
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 src_dir = os.path.dirname(current_dir)
@@ -309,3 +310,45 @@ def get_pod_logs(job_id):
             logging.info(f"Logs from pod {pod_name}:\n{pod_logs}")
         except client.exceptions.ApiException as e:
             logging.error(f"Error fetching logs for pod {pod_name}: {e}")
+
+def user_has_permissions(username: str):
+    client_id = "fileinvalidation-group-authorization"
+    client_secret = settings.GROUP_AUTHORIZATION_CLIENT_SECRET
+    group_id = "cms-dm-ops-core-team"  
+    keycloak_api_token_endpoint = "https://auth.cern.ch/auth/realms/cern/api-access/token"
+    authzsvc_endpoint = "https://authorization-service-api.web.cern.ch/api/v1.0/"
+    print("Getting API token...")
+    try:
+        token_resp = requests.post(
+            keycloak_api_token_endpoint,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "audience": "authorization-service-api"
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"}
+        )
+        token_resp.raise_for_status()
+        api_token = token_resp.json()['access_token']
+        print(f"Token received.\n")
+    except Exception as e:
+        print("Failed to get API token:", e)
+        return False
+        
+    print("Getting current group members...")
+
+    members_resp = requests.get(
+        f"{authzsvc_endpoint}Group/{group_id}/members/identities",
+        headers={"Authorization": f"Bearer {api_token}"}
+    )
+    try:
+        group_members_data = members_resp.json()['data']
+        allowed_users = [user['upn'] for user in group_members_data]
+        if username in allowed_users:
+            return True
+        else:
+            return False
+    except Exception as e:
+        print("Failed to get group members, falling back to denying permission", e)
+        return False

--- a/DMOps/file_invalidation_server/fi_manager/views.py
+++ b/DMOps/file_invalidation_server/fi_manager/views.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .models import FileInvalidationRequests
 from django.shortcuts import render
 from django.views.generic import TemplateView
-from .utils import process_invalidation, get_cern_username, send_approval_alert, create_ticket_for_invalidation, update_ticket, JiraStatus
+from .utils import *
 from django.db.models import Count, CharField, Value, F, Case, When, IntegerField
 from django.db.models.functions import StrIndex, Substr
 from django.utils.safestring import mark_safe
@@ -276,8 +276,7 @@ class InvalidationApproval(APIView):
             return Response({"message":f"Approval user cannot be the same as request user"},
                             status=status.HTTP_403_FORBIDDEN)
         
-        #TODO: Automate this list via CERN GMS API
-        if approve_user not in ['haozturk','cemmanou','ppaparri','jsalasga']:
+        if not user_has_permissions(approve_user):
             return Response({"message":f"Approval user must be part of cms-dm-ops-core-team"},
                             status=status.HTTP_403_FORBIDDEN)
 

--- a/DMOps/file_invalidation_server/file_invalidation_server/settings.py
+++ b/DMOps/file_invalidation_server/file_invalidation_server/settings.py
@@ -24,6 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config('SECRET_KEY')
 JIRA_PAT = config('JIRA_PAT')
+GROUP_AUTHORIZATION_CLIENT_SECRET = config('GROUP_AUTHORIZATION_CLIENT_SECRET')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Before this we hard coded the users that were allowed to approve invalidations requests, this PR uses the GMS API and the dedicated e-group (cms-dm-ops-core-team) to grant approval permissions.