### PR TITLE
Improve file integrity check + local testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 venv/
 dist
 DMOps/file_invalidation_server/fi_manager/migrations/
+
+# Local secrets and dev databases
+.env
+*.sqlite3

--- a/DMOps/file-integrity-check/generic-decompression-check/README.md
+++ b/DMOps/file-integrity-check/generic-decompression-check/README.md
@@ -60,3 +60,13 @@ returns:
 The tool requires `uproot` python module, `rucio` python client and `gfal2`.
 
 It is recommended to use it on lxplus after activating your voms proxy and by using CERNBox (eos) as the working directory.
+
+### Tests
+
+`run_check.py` has grid-free unit tests that stub out `gfal2`/`uproot`/`rucio`,
+so they run anywhere with no extra dependencies:
+
+```
+$ cd src
+$ python3 -m unittest test_run_check -v
+```

--- a/DMOps/file-integrity-check/generic-decompression-check/src/run_check.py
+++ b/DMOps/file-integrity-check/generic-decompression-check/src/run_check.py
@@ -15,6 +15,59 @@ from utils import ValidationStatus, setup_logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+def check_rse(
+    rse,
+    pfns,
+    adler,
+    workdir,
+    full_scan=False,
+    timeout_seconds=900,
+    copy_fn=copy_file_locally,
+    checksum_fn=checksum_check,
+    content_fn=content_check,
+):
+    """
+    Validate a file at a single RSE and return exactly one result dict.
+
+    PFNs of an RSE point at the same physical bytes via different access paths,
+    so we try them in order and validate the first one that copies — there is no
+    value in re-checking the same file through another path. Every PFN attempt
+    is logged. Only if *all* PFNs fail to copy do we report a single ERROR, so a
+    transient access failure on one PFN can never mask a healthy copy on another.
+
+    The copy/checksum/content callables are injectable to allow unit testing
+    without the grid stack.
+
+    Returns: {"rse": str, "pfn": str|None, "status": "OK"|"CORRUPTED"|"ERROR"}
+    """
+    last_pfn = None
+    for pfn in pfns:
+        last_pfn = pfn
+        local_path = None
+        try:
+            local_path = copy_fn(pfn, workdir)
+            if not local_path:
+                logger.error(f"PFN '{pfn}' on RSE '{rse}' -> copy failed; trying next PFN if available.")
+                continue
+
+            _, status = checksum_fn(local_path, adler)
+            if status != ValidationStatus.CORRUPTED:
+                _, status = content_fn(local_path, full_scan=full_scan, timeout_seconds=timeout_seconds)
+
+            logger.info(f"PFN '{pfn}' on RSE '{rse}' -> {status.value}")
+            return {"rse": rse, "pfn": pfn, "status": status.value}
+
+        finally:
+            if local_path and os.path.exists(local_path):
+                try:
+                    os.remove(local_path)
+                except OSError:
+                    logger.warning(f"Could not delete local file '{local_path}'. Please check manually.")
+
+    logger.warning(f"All PFNs failed to copy for RSE '{rse}' -> ERROR")
+    return {"rse": rse, "pfn": last_pfn, "status": ValidationStatus.ERROR.value}
+
+
 def check_files(
     lfns: List[str],
     workdir: str,
@@ -71,37 +124,17 @@ def check_files(
                         logger.info(f"LFN '{lfn}' skipped on RSE '{rse}' (state: {replica_state})")
                         continue
 
-                    for pfn in replica['rses'][rse]:
-                        local_path = None
-                        replica_result = {"rse": rse,  "pfn": pfn, "status": None}
-                        
-                        try:
-                            local_path = copy_file_locally(pfn, workdir)
-                            if not local_path:
-                                replica_result["status"] = ValidationStatus.ERROR.value
-                                file_result["replicas"].append(replica_result)
-                                logger.error(f"Failed to copy '{pfn}' locally from RSE '{rse}'. Skipping integrity checks.")
-                                continue
-                            
-                            _, replica_result["status"] = checksum_check(local_path, adler)
-                            if replica_result["status"] != ValidationStatus.CORRUPTED:
-                                _, replica_result["status"] = content_check(local_path, full_scan=full_scan, timeout_seconds=timeout_seconds)
-                            replica_result["status"] = replica_result["status"].value
-                            
-                        finally:
-                            
-                            if local_path and os.path.exists(local_path):
-                                try:
-                                    os.remove(local_path)
-                                except OSError:
-                                    logger.warning(f"Could not delete local file '{local_path}'. Please check manually.")
-
-                        file_result["replicas"].append(replica_result)
-
-                        break  # only one PFN per RSE is necessary for the check
-                    
-                    else:
-                        logger.warning(f"All PFNs failed for LFN '{lfn}' on RSE '{rse}'")
+                    # One result per RSE — see check_rse for the PFN handling.
+                    file_result["replicas"].append(
+                        check_rse(
+                            rse,
+                            replica['rses'][rse],
+                            adler,
+                            workdir,
+                            full_scan=full_scan,
+                            timeout_seconds=timeout_seconds,
+                        )
+                    )
 
         except Exception as e:
             file_result["error"] = str(e)

--- a/DMOps/file-integrity-check/generic-decompression-check/src/test_run_check.py
+++ b/DMOps/file-integrity-check/generic-decompression-check/src/test_run_check.py
@@ -1,0 +1,127 @@
+"""
+Grid-free unit tests for run_check.
+
+run_check pulls in the grid stack at import time (gfal2 via file_ops, uproot via
+check_decompression, rucio). We stub those modules in sys.modules before import
+so the tests run anywhere; the per-RSE logic takes its copy/checksum/content
+operations as injectable callables, so the real grid functions are never called.
+
+Run from this directory:
+    python3 -m unittest test_run_check -v
+"""
+import sys
+import unittest
+from unittest import mock
+
+for _mod in ("gfal2", "uproot", "rucio", "rucio.client"):
+    sys.modules.setdefault(_mod, mock.MagicMock())
+
+import run_check                       # noqa: E402
+from utils import ValidationStatus     # noqa: E402
+
+
+# (success_bool, ValidationStatus) tuples as returned by the real check functions
+OK        = (True,  ValidationStatus.OK)
+CORRUPTED = (False, ValidationStatus.CORRUPTED)
+ERROR     = (False, ValidationStatus.ERROR)
+
+
+def make_copy(reachable):
+    """copy_fn fake: returns a fake local path for reachable PFNs, else None."""
+    def _copy(pfn, workdir):
+        return f"/fake/{pfn}.root" if reachable.get(pfn) else None
+    return _copy
+
+
+class CheckRseTest(unittest.TestCase):
+
+    def test_single_pfn_ok(self):
+        result = run_check.check_rse(
+            "T1_X_Disk", ["pfnA"], "adler", "/tmp",
+            copy_fn=make_copy({"pfnA": True}),
+            checksum_fn=mock.Mock(return_value=OK),
+            content_fn=mock.Mock(return_value=OK),
+        )
+        self.assertEqual(result, {"rse": "T1_X_Disk", "pfn": "pfnA", "status": "OK"})
+
+    def test_first_pfn_fails_then_second_ok(self):
+        # The regression this fix targets: a transient copy failure on pfnA must
+        # not mask the healthy copy on pfnB. Exactly one row, OK, pfn=pfnB.
+        content_fn = mock.Mock(return_value=OK)
+        result = run_check.check_rse(
+            "T1_X_Disk", ["pfnA", "pfnB"], "adler", "/tmp",
+            copy_fn=make_copy({"pfnA": False, "pfnB": True}),
+            checksum_fn=mock.Mock(return_value=OK),
+            content_fn=content_fn,
+        )
+        self.assertEqual(result["status"], "OK")
+        self.assertEqual(result["pfn"], "pfnB")
+        content_fn.assert_called_once()        # validated once, only on pfnB
+
+    def test_all_pfns_fail_single_error(self):
+        result = run_check.check_rse(
+            "T1_X_Disk", ["pfnA", "pfnB"], "adler", "/tmp",
+            copy_fn=make_copy({"pfnA": False, "pfnB": False}),
+            checksum_fn=mock.Mock(return_value=OK),
+            content_fn=mock.Mock(return_value=OK),
+        )
+        self.assertEqual(result["status"], "ERROR")
+        self.assertEqual(result["pfn"], "pfnB")   # last attempted PFN, for context
+
+    def test_checksum_corrupted_skips_content(self):
+        content_fn = mock.Mock(return_value=OK)
+        result = run_check.check_rse(
+            "T1_X_Disk", ["pfnA"], "adler", "/tmp",
+            copy_fn=make_copy({"pfnA": True}),
+            checksum_fn=mock.Mock(return_value=CORRUPTED),
+            content_fn=content_fn,
+        )
+        self.assertEqual(result["status"], "CORRUPTED")
+        content_fn.assert_not_called()
+
+    def test_checksum_ok_content_corrupted(self):
+        result = run_check.check_rse(
+            "T1_X_Disk", ["pfnA"], "adler", "/tmp",
+            copy_fn=make_copy({"pfnA": True}),
+            checksum_fn=mock.Mock(return_value=OK),
+            content_fn=mock.Mock(return_value=CORRUPTED),
+        )
+        self.assertEqual(result["status"], "CORRUPTED")
+
+
+class CheckFilesTest(unittest.TestCase):
+
+    def _replicas(self):
+        return [{
+            "adler32": "abc",
+            "rses": {"T1_X_Disk": ["pfnA", "pfnB"], "T2_Y_Disk": ["pfnC"]},
+            "states": {"T1_X_Disk": "AVAILABLE", "T2_Y_Disk": "UNAVAILABLE"},
+        }]
+
+    def test_one_row_per_available_rse(self):
+        fake_client = mock.MagicMock()
+        fake_client.list_replicas.return_value = self._replicas()
+
+        calls = []
+
+        def fake_check_rse(rse, pfns, adler, workdir, **kwargs):
+            calls.append(rse)
+            return {"rse": rse, "pfn": pfns[0], "status": "OK"}
+
+        with mock.patch.object(run_check, "RucioClient", return_value=fake_client), \
+             mock.patch.object(run_check, "check_rse", side_effect=fake_check_rse):
+            results = run_check.check_files(["cms:/store/x.root"], "/tmp")
+
+        # Only the AVAILABLE RSE is checked → one replica row, one check_rse call
+        self.assertEqual(calls, ["T1_X_Disk"])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0]["replicas"]), 1)
+        self.assertEqual(results[0]["replicas"][0]["rse"], "T1_X_Disk")
+
+    def test_non_root_lfn_rejected(self):
+        results = run_check.check_files(["cms:/store/dataset"], "/tmp")
+        self.assertEqual(results[0]["error"], "The LFN provided is not a .root file.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/DMOps/file_invalidation_server/file_integrity_checker/README.md
+++ b/DMOps/file_invalidation_server/file_integrity_checker/README.md
@@ -72,8 +72,10 @@ file_invalidation_server/
 │
 └── controllers/
     ├── job_integrity.yaml                      — Kubernetes Job template for the checker
-    ├── cronjob_queue_processor_integrity.yaml  — CronJob for process_queue.py
-    ├── cronjob_integrity_process_jobs.yaml     — CronJob for process_jobs.py
+    ├── cronjob_integrity_process_queue.yaml    — CronJob for process_queue.py
+    ├── cronjob_process_jobs.yaml               — CronJob (jobs-log-processor): runs both
+    │                                             fi_manager/process_jobs.py and
+    │                                             file_integrity_checker/process_jobs.py
     └── cronjob_integrity_cleanup_jobs.yaml     — CronJob for cleanup_jobs.py
 ```
 
@@ -133,12 +135,17 @@ Submit a new file integrity check request.
 | `full_scan` | No | If true, reads every basket. More thorough but slower. Default: false. |
 
 **Example response (201 Created):**
+
+The request is only *queued* at submit time — `process_queue.py` assigns the
+`job_id` and moves it to `IN_PROGRESS` on its next run. So the response reports
+`status: SUBMITTED` and a `job_id` of `null`. Poll the `links` for progress.
+
 ```json
 {
-    "message": "2 LFN(s) submitted for integrity check. Job ID: abc12345.",
+    "message": "2 LFN(s) submitted for integrity check. The request is queued; a job will be assigned shortly. Track progress via the links below.",
     "request_id": "...",
-    "job_id": "abc12345",
-    "status": "IN_PROGRESS",
+    "job_id": null,
+    "status": "SUBMITTED",
     "links": {
         "detail":   "https://file-invalidation.app.cern.ch/api/integrity/query/requests/?request_id=...",
         "files":    "https://file-invalidation.app.cern.ch/api/integrity/query/files/?request_id=...",
@@ -308,96 +315,64 @@ All variables use the `FIC_` prefix (File Integrity Checker). All have sensible 
 
 ### Prerequisites
 
-- Python 3.9 on lxplus
-- CERN environment with Rucio available via CVMFS
+- Python 3.9+ (lxplus has 3.9; 3.11–3.13 also work in a venv)
+- CERN environment with Rucio available via CVMFS (only needed to exercise the
+  real tool — not needed to run the test suite)
 
-### Setup
+### Self-contained local mode (`LOCAL_TESTING`)
 
-The server uses MySQL in production but SQLite locally. Add `USE_SQLITE=true` to your `.env` and patch the `DATABASES` block in `../file_invalidation_server/settings.py`:
-
-```python
-# Replace 'JIRA_PAT = config('JIRA_PAT')' with:
-JIRA_PAT = config('JIRA_PAT', default='')
-
-# Replace the DATABASES block with:
-if config('USE_SQLITE', default='false') == 'true':
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
-        }
-    }
-else:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': config('DB_NAME'),
-            'USER': config('DB_USER'),
-            'PASSWORD': config('DB_PASSWORD'),
-            'HOST': config('DB_HOST', default='localhost'),
-            'PORT': config('DB_PORT', default='3306', cast=int),
-            'OPTIONS': {'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"}
-        }
-    }
-```
-
-Update the following elements `../fi_manager/models.py`:
-
-```python
-    rse = models.TextField(blank=True, null=True)
-    request_user = models.TextField(blank=True, null=True)
-    approve_user = models.TextField(blank=True, null=True)
-
-    class Meta:
-        managed = True
-        db_table = 'file_invalidation_requests'
-        unique_together = (('request_id', 'file_name'),)
-```
-
-Create a `../.env` file in the project root:
+The server uses MySQL and CERN secrets in production. For local work, set the
+`LOCAL_TESTING=true` environment variable. This is read in `settings.py` and
+switches the database to a local SQLite file and fills the required secrets
+(`SECRET_KEY`, `JIRA_PAT`, `GROUP_AUTHORIZATION_CLIENT_SECRET`) with harmless dev
+defaults — **no `.env` file and no source edits are required.** With
+`LOCAL_TESTING` unset (the default) production behaviour is unchanged.
 
 ```bash
-SECRET_KEY=any-local-dev-string
-USE_SQLITE=true
-DB_NAME=db.sqlite3
-DB_USER=admin
-DB_PASSWORD=password
-DB_HOST=localhost
-DB_PORT=3306
-FIC_MAX_LFNS_PER_REQUEST=20
-FIC_PVC_MOUNT_PATH_HOST=/shared-data-integrity
-FIC_PVC_MOUNT_PATH_CONTAINER=/input
-FIC_JOB_WORKDIR=/tmp
-FIC_NAMESPACE=file-invalidation-tool
-FIC_JOB_LOG_VERBOSITY=2
+# From file_invalidation_server/ — install deps once into a venv
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
 ```
 
-### Running locally
+### Running the tests
 
 ```bash
 # From file_invalidation_server/
-
-# Apply migrations
-python3 manage.py makemigrations file_integrity_checker
-python3 manage.py migrate file_integrity_checker
-
-# Run tests
-python3 manage.py test file_integrity_checker
-
-# Seed the DB with test data for this app
-python3 manage.py shell < populate_db_integrity.py
-
-# Start the dev server
-python3 manage.py runserver 0.0.0.0:8080
+LOCAL_TESTING=true python3 manage.py test file_integrity_checker
 ```
 
-Open an SSH tunnel from your laptop:
+The test DB is built from the migrations (the `managed = False` models still get
+their tables created during test setup). 62 tests covering: scope parsing,
+request creation, replica creation, queue processing (mocked K8s), tool output
+parsing, replica update logic (including idempotency), file-status derivation,
+boolean query-param coercion, plain-text formatting, HTML template rendering,
+and all API endpoints.
+
+### Running the dev server + accessing the UI
+
+```bash
+# From file_invalidation_server/
+LOCAL_TESTING=true python3 manage.py migrate
+LOCAL_TESTING=true python3 manage.py shell < populate_db_integrity.py   # optional seed data
+LOCAL_TESTING=true python3 manage.py runserver 0.0.0.0:8080
+```
+
+If you are on lxplus, open an SSH tunnel from your laptop:
 
 ```bash
 ssh -L 8080:localhost:8080 yourusername@lxplus.cern.ch
 ```
 
-Then visit `http://localhost:8080/api/integrity/submit/`
+The browsable UI pages (rendered HTML) are:
+
+| Page | URL |
+|---|---|
+| Submit a request (form) | `http://localhost:8080/api/integrity/submit/` |
+| Requests list | `http://localhost:8080/api/integrity/query/requests/` |
+| Request detail (files + replicas) | `…/api/integrity/query/requests/?request_id=<uuid>` |
+| Files / replicas (linked from detail) | `…/api/integrity/query/files/` and `…/query/replicas/` |
+
+In production the same pages live under `https://file-invalidation.app.cern.ch`.
 
 ### Expected local behaviour
 
@@ -415,11 +390,29 @@ curl -X POST http://localhost:8080/api/integrity/submit/ \
   -d '{"lfns": "cms:/store/data/Run2024/file.root"}'
 ```
 
-### Running tests
+---
 
-```bash
-# From file_invalidation_server/
-python3 manage.py test file_integrity_checker
-```
+## Deployment
 
-43 tests covering: scope parsing, request creation, replica creation, job triggering (mocked), tool output parsing, replica update logic (including idempotency), file status derivation, plain text formatting, and all API endpoints.
+The app runs on CERN's OKD (OpenShift) cluster in the `file-invalidation-tool`
+namespace, alongside the file invalidation server (they share the Django project
+and image `registry.paas.cern.ch/file-invalidation-tool/...`).
+
+**Managed in OKD (not in this repo):** the Django `Deployment`, its `Route`
+(`https://file-invalidation.app.cern.ch`), the oauth2-proxy sidecar that injects
+the CERN SSO username header, the `integrity-input-file-pvc`, and the DB/secret
+objects referenced by the manifests below.
+
+**Versioned in this repo** — apply with `oc apply -f <file> -n file-invalidation-tool`:
+
+| Manifest | Kind | Role |
+|---|---|---|
+| `controllers/job_integrity.yaml` | Job | Template the queue processor patches and submits per request |
+| `controllers/cronjob_integrity_process_queue.yaml` | CronJob (1 min) | Runs `process_queue.py` — picks up SUBMITTED requests |
+| `controllers/cronjob_process_jobs.yaml` | CronJob (5 min) | `jobs-log-processor`: runs **both** `fi_manager/process_jobs.py` and `file_integrity_checker/process_jobs.py` |
+| `controllers/cronjob_integrity_cleanup_jobs.yaml` | CronJob | Runs `cleanup_jobs.py` — removes orphaned PVC files and old K8s jobs |
+
+> Note: any management script that calls `django.setup()` (the three CronJobs
+> above) needs the same env/secrets as the web pod — `SECRET_KEY`, `JIRA_PAT`,
+> `GROUP_AUTHORIZATION_CLIENT_SECRET`, and `DB_*` — because `settings.py` reads
+> them at import time.

--- a/DMOps/file_invalidation_server/file_integrity_checker/tests.py
+++ b/DMOps/file_invalidation_server/file_integrity_checker/tests.py
@@ -568,3 +568,93 @@ class ViewEndpointTest(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertIn('text/plain', r['Content-Type'])
         self.assertIn('T1_US_FNAL_Disk', r.content.decode())
+
+
+class QueryBoolParamsTest(TestCase):
+    """
+    Regression tests for the include_* boolean query params on the requests
+    view. These were broken when a refactor dropped the string->bool coercion,
+    making "false" truthy so the toggles silently did nothing.
+    """
+
+    def setUp(self):
+        self.client = Client(HTTP_ACCEPT='application/json')
+        self.request = FileIntegrityRequest.objects.create(
+            requested_by='testuser',
+            status=FileIntegrityRequest.Status.COMPLETED,
+            job_id='aabb1122',
+            logs='some pod logs here',
+        )
+        FileReplica.objects.create(
+            request=self.request, scope='cms',
+            lfn='/store/data/file1.root',
+            rse='T1_US_FNAL_Disk', status='OK'
+        )
+
+    def _detail(self, extra=''):
+        return self.client.get(
+            f'/api/integrity/query/requests/?request_id={self.request.request_id}{extra}'
+        ).json()
+
+    # --- detail view defaults ---
+
+    def test_detail_includes_files_and_summary_by_default(self):
+        data = self._detail()
+        self.assertIn('files', data)
+        self.assertIn('summary', data)
+        self.assertNotIn('logs', data)
+
+    # --- the actual bug: =false must turn things off ---
+
+    def test_include_replicas_false_omits_files(self):
+        self.assertNotIn('files', self._detail('&include_replicas=false'))
+
+    def test_include_summary_false_omits_summary(self):
+        self.assertNotIn('summary', self._detail('&include_summary=false'))
+
+    def test_include_logs_true_includes_logs(self):
+        self.assertIn('logs', self._detail('&include_logs=true'))
+
+    def test_include_replicas_true_keeps_files(self):
+        self.assertIn('files', self._detail('&include_replicas=true'))
+
+    # --- list view: summary off by default, costs a query per request ---
+
+    def test_list_omits_summary_by_default(self):
+        rows = self.client.get('/api/integrity/query/requests/').json()
+        self.assertTrue(all('summary' not in row for row in rows))
+
+    def test_list_includes_summary_when_requested(self):
+        rows = self.client.get(
+            '/api/integrity/query/requests/?include_summary=true'
+        ).json()
+        self.assertTrue(all('summary' in row for row in rows))
+
+    # --- UI safety: the HTML templates must still render ---
+
+    def test_html_list_renders(self):
+        html_client = Client(HTTP_ACCEPT='text/html')
+        r = html_client.get('/api/integrity/query/requests/')
+        self.assertEqual(r.status_code, 200)
+
+    def test_html_detail_renders(self):
+        html_client = Client(HTTP_ACCEPT='text/html')
+        r = html_client.get(
+            f'/api/integrity/query/requests/?request_id={self.request.request_id}'
+        )
+        self.assertEqual(r.status_code, 200)
+
+
+class SubmitResponseTest(TestCase):
+    """The submit response must not advertise a bogus 'Job ID: None'."""
+
+    def test_queued_message_has_no_null_job_id(self):
+        client = Client(HTTP_ACCEPT='application/json')
+        r = client.post(
+            '/api/integrity/submit/',
+            data={'lfns': 'cms:/store/data/Run2024/file.root'},
+        )
+        self.assertEqual(r.status_code, 201)
+        data = r.json()
+        self.assertNotIn('Job ID: None', data['message'])
+        self.assertEqual(data['status'], FileIntegrityRequest.Status.SUBMITTED)

--- a/DMOps/file_invalidation_server/file_integrity_checker/views.py
+++ b/DMOps/file_invalidation_server/file_integrity_checker/views.py
@@ -24,6 +24,22 @@ def get_username(request):
     return get_cern_username(request) or 'unknown'
 
 
+def query_bool(request, param, default):
+    """
+    Parses a query-string parameter as a boolean.
+
+    Query params always arrive as strings, so a bare `if request.query_params.get(...)`
+    treats "false" as truthy. This coerces explicitly:
+        missing                              -> default
+        'false' / '0' / 'no' / 'off' / ''    -> False
+        anything else (e.g. 'true')          -> True
+    """
+    raw = request.query_params.get(param)
+    if raw is None:
+        return default
+    return str(raw).strip().lower() not in ('false', '0', 'no', 'off', '')
+
+
 def derive_file_status(replica_statuses):
     """
     Derives a single human-readable status for a file based on its replicas.
@@ -240,11 +256,15 @@ class FileIntegritySubmitRequestView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
+        # Jobs are no longer triggered synchronously here — the queue processor
+        # picks the request up and assigns a job_id. So at submit time job_id is
+        # None and the status is SUBMITTED; report that honestly.
         return Response(
             {
                 'message':    (
                     f"{len(lfns)} LFN(s) submitted for integrity check. "
-                    f"Job ID: {job_id}."
+                    f"The request is queued; a job will be assigned shortly. "
+                    f"Track progress via the links below."
                 ),
                 'request_id': str(integrity_request.request_id),
                 'job_id':     job_id,
@@ -308,9 +328,12 @@ class FileIntegrityQueryRequestView(APIView):
         request_id       = request.query_params.get('request_id')
         query_status     = request.query_params.get('status')
         requested_by     = request.query_params.get('requested_by')
-        include_replicas = request.query_params.get('include_replicas',True)
-        include_logs = request.query_params.get('include_logs',False)
-        include_summary = request.query_params.get('include_summary',True)
+        # Booleans must be coerced from their string query-param form, otherwise
+        # "false" is truthy. include_summary defaults on for the detail view and
+        # off for the list view (where it would cost one query per request).
+        include_replicas = query_bool(request, 'include_replicas', True)
+        include_logs     = query_bool(request, 'include_logs', False)
+        include_summary  = query_bool(request, 'include_summary', bool(request_id))
 
         # --- Detail view ---
         if request_id:

--- a/DMOps/file_invalidation_server/file_invalidation_server/settings.py
+++ b/DMOps/file_invalidation_server/file_invalidation_server/settings.py
@@ -21,14 +21,26 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY')
-JIRA_PAT = config('JIRA_PAT')
-GROUP_AUTHORIZATION_CLIENT_SECRET = config('GROUP_AUTHORIZATION_CLIENT_SECRET')
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-LOCAL_TESTING = False
+
+# LOCAL_TESTING enables a self-contained local setup (SQLite + dummy secrets)
+# so the test suite and dev server run with no source edits or .env file.
+# Defaults to False — production behaviour is unchanged. Enable it per command
+# with the LOCAL_TESTING=true environment variable.
+LOCAL_TESTING = config('LOCAL_TESTING', default=False, cast=bool)
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# In production these are required. Under LOCAL_TESTING they fall back to
+# harmless dev defaults so no secrets are needed to run the tests.
+if LOCAL_TESTING:
+    SECRET_KEY = config('SECRET_KEY', default='dev-insecure-secret-key')
+    JIRA_PAT = config('JIRA_PAT', default='')
+    GROUP_AUTHORIZATION_CLIENT_SECRET = config('GROUP_AUTHORIZATION_CLIENT_SECRET', default='')
+else:
+    SECRET_KEY = config('SECRET_KEY')
+    JIRA_PAT = config('JIRA_PAT')
+    GROUP_AUTHORIZATION_CLIENT_SECRET = config('GROUP_AUTHORIZATION_CLIENT_SECRET')
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1','0.0.0.0','file-invalidation.app.cern.ch','file-invalidation-test.app.cern.ch']
 


### PR DESCRIPTION
Makes both DMOps apps testable without cluster secrets or a VOMS proxy, and tightens how the integrity checker handles a file's PFNs.

### Local testing environment

Added a LOCAL_TESTING switch in settings.py. Set LOCAL_TESTING=true and the app runs self-contained — SQLite plus dummy secrets — so the suite runs with no .env and no source edits:

`LOCAL_TESTING=true python manage.py test`

It defaults to False, so production is untouched. On master, settings.py fails to import unless SECRET_KEY, JIRA_PAT, and GROUP_AUTHORIZATION_CLIENT_SECRET are set — which blocked every test, including the invalidation tool's fi_manager tests, from starting. LOCAL_TESTING=true supplies dummy values so the whole suite runs.

### Integrity check

- run_check.py: new check_rse helper — an RSE's PFNs are just different access paths to the same bytes, so it tries them in order, validates the first one that copies, and returns a single result per RSE (OK/CORRUPTED/ERROR). It falls through to the next PFN only when a copy fails, and reports ERROR only if all fail — so a transient access failure can't mask a healthy copy. Every attempt is logged.
- New grid-free tests (test_run_check.py) that mock Rucio/gfal so they run anywhere.
- file_integrity_checker: fixed the include_* query params, corrected the submit-response wording, added tests.
- Docs (both READMEs) and .gitignore cleanup.